### PR TITLE
Feature/#2 1 authentication test

### DIFF
--- a/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     REFRESH_TOKEN_IS_NULL_ERROR(AUTH, 1, SC_NOT_ACCEPTABLE, "로그아웃 상태입니다."),
     INVALID_TOKEN(AUTH, 2, SC_BAD_REQUEST, "유효하지 않은 토큰입니다."),
     USERNAME_NOT_FOUND(AUTH, 3, SC_NOT_FOUND, "존재하지 않는 아이디 입니다."),
+    HANDLE_UNAUTHORIZED(AUTH, 4, SC_UNAUTHORIZED, "인증되지 않은 사용자입니다."),
 
     MEMBER_NOT_FOUND(MEMBER, 1, SC_NOT_FOUND, "존재하지 않는 회원입니다."),
     ;

--- a/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
@@ -1,9 +1,6 @@
 package com.dnd.niceteam.security;
 
-import com.dnd.niceteam.security.jwt.JwtAuthenticationCheckFilter;
-import com.dnd.niceteam.security.jwt.JwtAuthenticationFilter;
-import com.dnd.niceteam.security.jwt.JwtAuthenticationSuccessHandler;
-import com.dnd.niceteam.security.jwt.JwtTokenProvider;
+import com.dnd.niceteam.security.jwt.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationContext;
@@ -60,6 +57,9 @@ public class SecurityConfig {
 
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(jwtAuthenticationCheckFilter(), UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(config -> config
+                        .authenticationEntryPoint(new JwtAuthenticationEntryPoint(objectMapper))
+                )
 
                 .authorizeRequests(antz -> antz
                         .antMatchers(HttpMethod.GET, GET_PERMITTED_URLS).permitAll()

--- a/src/main/java/com/dnd/niceteam/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/dnd/niceteam/security/jwt/JwtAuthenticationEntryPoint.java
@@ -15,6 +15,9 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
+/**
+ * JWT Access Token 이 없는 상태로 요청을 보내거나, 토큰 만료, 유효하지 않은 토큰 등을 이용했을 경우 호출
+ */
 @RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 

--- a/src/main/java/com/dnd/niceteam/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/dnd/niceteam/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,38 @@
+package com.dnd.niceteam.security.jwt;
+
+import com.dnd.niceteam.common.dto.ApiResult;
+import com.dnd.niceteam.error.dto.ErrorResponseDto;
+import com.dnd.niceteam.error.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException, ServletException {
+        ErrorCode errorCode = ErrorCode.HANDLE_UNAUTHORIZED;
+        ErrorResponseDto errorResponseDto = ErrorResponseDto.of(errorCode);
+        ApiResult<Void> result = ApiResult.<Void>builder()
+                .status(ApiResult.Status.FAIL)
+                .error(errorResponseDto)
+                .build();
+        response.setStatus(errorCode.getStatus());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        objectMapper.writeValue(response.getWriter(), result);
+    }
+}

--- a/src/main/java/com/dnd/niceteam/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dnd/niceteam/security/jwt/JwtTokenProvider.java
@@ -37,6 +37,8 @@ public class JwtTokenProvider {
 
     private final UserDetailsService userDetailsService;
 
+    private final JwtParser jwtParser;
+
     public JwtTokenProvider(
             @Value("${jwt.access-token-validity}") long accessTokenValidity,
             @Value("${jwt.refresh-token-validity}") long refreshTokenValidity,
@@ -46,6 +48,7 @@ public class JwtTokenProvider {
         this.accessTokenValidityInMillis = accessTokenValidity * 1000;
         this.refreshTokenValidityInMillis = refreshTokenValidity * 1000;
         this.userDetailsService = userDetailsService;
+        this.jwtParser = Jwts.parserBuilder().setSigningKey(secretKey).build();
     }
 
     public String createAccessToken(String username) {
@@ -71,7 +74,7 @@ public class JwtTokenProvider {
     // 토큰 유효성 및 만료기간 검사
     public boolean validateToken(String token) {
         try {
-            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            jwtParser.parseClaimsJws(token);
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             log.info("Invalid JWT signature.");
@@ -91,16 +94,8 @@ public class JwtTokenProvider {
 
     // 토큰에서 인증 정보 추출
     public Authentication getAuthentication(String accessToken) {
-        String usernameFromToken = getUsernameFromToken(accessToken);
+        String usernameFromToken = jwtParser.parseClaimsJws(accessToken).getBody().getSubject();
         UserDetails userDetails = userDetailsService.loadUserByUsername(usernameFromToken);
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-    }
-
-    private String getUsernameFromToken(String token) {
-        return parseClaimsJws(token).getBody().getSubject();
-    }
-
-    private Jws<Claims> parseClaimsJws(String token) {
-        return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
     }
 }

--- a/src/test/java/com/dnd/niceteam/security/AuthApiTest.java
+++ b/src/test/java/com/dnd/niceteam/security/AuthApiTest.java
@@ -1,6 +1,7 @@
 package com.dnd.niceteam.security;
 
 import com.dnd.niceteam.common.RestDocsConfig;
+import com.dnd.niceteam.common.dto.ApiResult;
 import com.dnd.niceteam.member.domain.Member;
 import com.dnd.niceteam.member.repository.MemberRepository;
 import com.dnd.niceteam.security.auth.dto.AuthRequestDto;
@@ -23,6 +24,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -71,6 +73,9 @@ class AuthApiTest {
                         .content(objectMapper.writeValueAsString(loginDto)))
                 .andDo(print())
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(ApiResult.Status.SUCCESS.name()))
+                .andExpect(jsonPath("$.data.accessToken").exists())
+                .andExpect(jsonPath("$.data.refreshToken").exists())
                 .andDo(document("auth-login",
                         requestFields(
                                 fieldWithPath("username").description("로그인 아이디"),

--- a/src/test/java/com/dnd/niceteam/security/JwtWebTest.java
+++ b/src/test/java/com/dnd/niceteam/security/JwtWebTest.java
@@ -1,0 +1,87 @@
+package com.dnd.niceteam.security;
+
+import com.dnd.niceteam.common.RestDocsConfig;
+import com.dnd.niceteam.common.dto.ApiResult;
+import com.dnd.niceteam.error.exception.ErrorCode;
+import com.dnd.niceteam.member.domain.Member;
+import com.dnd.niceteam.member.repository.MemberRepository;
+import com.dnd.niceteam.security.jwt.JwtTokenProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Import(RestDocsConfig.class)
+@Transactional
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+class JwtWebTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private UserDetailsService userDetailsService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @Test
+    @DisplayName("만료된 토큰으로 요청")
+    void expiredJwtToken() throws Exception {
+        //given
+        JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(
+                0L, 3600L, jwtSecret, userDetailsService);
+        Member member = memberRepository.save(Member.builder()
+                .username("test-username")
+                .password(passwordEncoder.encode("testPassword11!"))
+                .email("test@email.com")
+                .name("test-name")
+                .build());
+        String accessToken = jwtTokenProvider.createAccessToken(member.getUsername());
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getUsername());
+        member.setRefreshToken(refreshToken);
+        em.flush();
+        em.clear();
+
+        //expected
+        mockMvc.perform(get("/not-exist-path-for-test")
+                        .header(HttpHeaders.AUTHORIZATION, JwtTokenProvider.TOKEN_PREFIX + accessToken))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(ApiResult.Status.FAIL.name()))
+                .andExpect(jsonPath("$.error.code").value(ErrorCode.HANDLE_UNAUTHORIZED.getCode()))
+                .andExpect(jsonPath("$.error.message").value(ErrorCode.HANDLE_UNAUTHORIZED.getMessage()))
+                .andExpect(jsonPath("$.error.errors").isEmpty());
+    }
+}


### PR DESCRIPTION
# 구현 내용/방법

> 간단하게 구현한 내용과 방법에 대한 설명

- refresh token 로직을 위해서 access token 이 만료되었을 경우를 클라이언트에 알려주기 위해 JwtAuthenticationEntryPoint 를 추가하였습니다.
- JwtAuthenticationEntryPoint는 현재 jwt 를 JwtTokenProvider.validate 하였을때 통과하지 못 하거나 Authorization 헤더에 토큰을 포함하지 않았을 경우 호출되도록 되어있습니다.
