### PR TITLE
feature#2-2 JWT 인증 필터 빈 등록 및 로그아웃 구성

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -8,7 +8,14 @@
 :operation-http-request-title: Example request
 :operation-http-response-title: Example response
 
+
 [[auth-login]]
 == Login
 
 operation::auth-login[snippets='http-request,request-fields,http-response,response-fields-data']
+
+
+[[auth-logout]]
+== Logout
+
+operation::auth-logout[snippets='http-request,request-headers,http-response']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -14,30 +14,9 @@
 
 == API 응답 결과
 
-[source]
-----
-object {
-    string status;
-    object {
-        // 응답 데이터
-    }* data?;
-    object {
-        integer code?;
-        string message?;
-        array [
-            object {
-                string field?;
-                string value?;
-                string reason?;
-            }*;
-        ] errors?;
-    }* error?;
-}*;
-----
-
 .$.status
 - SUCCESS: 요청 성공
 - FAIL: 요청 실패
 - ERROR: 서버 에러
 
-operation::common-ApiResult[snippets='http-request,request-headers,response-fields,http-response']
+operation::common-ApiResult[snippets='http-request,request-headers,http-response,response-fields']

--- a/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
@@ -1,10 +1,7 @@
 package com.dnd.niceteam.security;
 
 import com.dnd.niceteam.member.repository.MemberRepository;
-import com.dnd.niceteam.security.jwt.JwtAuthenticationCheckFilter;
-import com.dnd.niceteam.security.jwt.JwtAuthenticationEntryPoint;
-import com.dnd.niceteam.security.jwt.JwtAuthenticationFilter;
-import com.dnd.niceteam.security.jwt.JwtTokenProvider;
+import com.dnd.niceteam.security.jwt.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationContext;
@@ -43,10 +40,9 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(
-            HttpSecurity httpSecurity,
-            JwtAuthenticationCheckFilter jwtAuthenticationCheckFilter,
-            JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
-            JwtAuthenticationFilter jwtAuthenticationFilter
+            HttpSecurity httpSecurity, JwtAuthenticationCheckFilter jwtAuthenticationCheckFilter,
+            JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint, JwtAuthenticationFilter jwtAuthenticationFilter,
+            JwtLogoutHandler jwtLogoutHandler, JwtLogoutSuccessHandler jwtLogoutSuccessHandler
     ) throws Exception {
         return httpSecurity
                 .cors()
@@ -64,6 +60,10 @@ public class SecurityConfig {
                 .exceptionHandling(config -> config
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 )
+
+                .logout(logout -> logout
+                        .addLogoutHandler(jwtLogoutHandler)
+                        .logoutSuccessHandler(jwtLogoutSuccessHandler))
 
                 .authorizeRequests(antz -> antz
                         .antMatchers(HttpMethod.GET, GET_PERMITTED_URLS).permitAll()
@@ -114,5 +114,15 @@ public class SecurityConfig {
     @Bean
     public JwtAuthenticationCheckFilter jwtAuthenticationCheckFilter(JwtTokenProvider jwtTokenProvider) {
         return new JwtAuthenticationCheckFilter(jwtTokenProvider);
+    }
+
+    @Bean
+    public JwtLogoutHandler jwtLogoutHandler(JwtTokenProvider jwtTokenProvider, MemberRepository memberRepository) {
+        return new JwtLogoutHandler(jwtTokenProvider, memberRepository);
+    }
+
+    @Bean
+    public JwtLogoutSuccessHandler jwtLogoutSuccessHandler(ObjectMapper objectMapper) {
+        return new JwtLogoutSuccessHandler(objectMapper);
     }
 }

--- a/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.dnd.niceteam.security;
 
+import com.dnd.niceteam.member.repository.MemberRepository;
 import com.dnd.niceteam.security.jwt.JwtAuthenticationCheckFilter;
 import com.dnd.niceteam.security.jwt.JwtAuthenticationEntryPoint;
 import com.dnd.niceteam.security.jwt.JwtAuthenticationFilter;
@@ -105,15 +106,13 @@ public class SecurityConfig {
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter(
-            JwtTokenProvider jwtTokenProvider, ObjectMapper objectMapper, AuthenticationManager authenticationManager) {
-        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(
-                jwtTokenProvider, authenticationManager, objectMapper);
-        return jwtAuthenticationFilter;
+            JwtTokenProvider jwtTokenProvider, MemberRepository memberRepository,
+            ObjectMapper objectMapper, AuthenticationManager authenticationManager) {
+        return new JwtAuthenticationFilter(jwtTokenProvider, memberRepository, authenticationManager, objectMapper);
     }
 
     @Bean
     public JwtAuthenticationCheckFilter jwtAuthenticationCheckFilter(JwtTokenProvider jwtTokenProvider) {
-        JwtAuthenticationCheckFilter jwtAuthenticationCheckFilter = new JwtAuthenticationCheckFilter(jwtTokenProvider);
-        return jwtAuthenticationCheckFilter;
+        return new JwtAuthenticationCheckFilter(jwtTokenProvider);
     }
 }

--- a/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -55,7 +56,7 @@ public class SecurityConfig {
                 .formLogin().disable()
                 .httpBasic().disable()
 
-                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter(authenticationManager(context)), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(jwtAuthenticationCheckFilter(), UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(config -> config
                         .authenticationEntryPoint(new JwtAuthenticationEntryPoint(objectMapper))
@@ -75,11 +76,16 @@ public class SecurityConfig {
     }
 
     @Bean
-    public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
-        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(objectMapper);
+    public AuthenticationManager authenticationManager(ApplicationContext context) throws Exception {
         AuthenticationManagerFactoryBean authenticationManagerFactoryBean = new AuthenticationManagerFactoryBean();
         authenticationManagerFactoryBean.setBeanFactory(context);
-        jwtAuthenticationFilter.setAuthenticationManager(authenticationManagerFactoryBean.getObject());
+        return authenticationManagerFactoryBean.getObject();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(AuthenticationManager authenticationManager) {
+        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(objectMapper);
+        jwtAuthenticationFilter.setAuthenticationManager(authenticationManager);
         jwtAuthenticationFilter.setAuthenticationSuccessHandler(new JwtAuthenticationSuccessHandler(
                 jwtTokenProvider, objectMapper));
         return jwtAuthenticationFilter;

--- a/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
@@ -56,8 +56,10 @@ public class SecurityConfig {
                 .formLogin().disable()
                 .httpBasic().disable()
 
-                .addFilterBefore(jwtAuthenticationFilter(authenticationManager(context)), UsernamePasswordAuthenticationFilter.class)
-                .addFilterAfter(jwtAuthenticationCheckFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter(jwtTokenProvider, objectMapper, authenticationManager(context)),
+                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(jwtAuthenticationCheckFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(config -> config
                         .authenticationEntryPoint(new JwtAuthenticationEntryPoint(objectMapper))
                 )
@@ -83,7 +85,8 @@ public class SecurityConfig {
     }
 
     @Bean
-    public JwtAuthenticationFilter jwtAuthenticationFilter(AuthenticationManager authenticationManager) {
+    public JwtAuthenticationFilter jwtAuthenticationFilter(
+            JwtTokenProvider jwtTokenProvider, ObjectMapper objectMapper, AuthenticationManager authenticationManager) {
         JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(objectMapper);
         jwtAuthenticationFilter.setAuthenticationManager(authenticationManager);
         jwtAuthenticationFilter.setAuthenticationSuccessHandler(new JwtAuthenticationSuccessHandler(
@@ -92,7 +95,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public JwtAuthenticationCheckFilter jwtAuthenticationCheckFilter() {
+    public JwtAuthenticationCheckFilter jwtAuthenticationCheckFilter(JwtTokenProvider jwtTokenProvider) {
         JwtAuthenticationCheckFilter jwtAuthenticationCheckFilter = new JwtAuthenticationCheckFilter(jwtTokenProvider);
         return jwtAuthenticationCheckFilter;
     }

--- a/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
                 .addFilterAfter(jwtAuthenticationCheckFilter(jwtTokenProvider),
                         UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(config -> config
-                        .authenticationEntryPoint(new JwtAuthenticationEntryPoint(objectMapper))
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint(objectMapper))
                 )
 
                 .authorizeRequests(antz -> antz
@@ -82,6 +82,11 @@ public class SecurityConfig {
         AuthenticationManagerFactoryBean authenticationManagerFactoryBean = new AuthenticationManagerFactoryBean();
         authenticationManagerFactoryBean.setBeanFactory(context);
         return authenticationManagerFactoryBean.getObject();
+    }
+
+    @Bean
+    public JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        return new JwtAuthenticationEntryPoint(objectMapper);
     }
 
     @Bean

--- a/src/main/java/com/dnd/niceteam/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/dnd/niceteam/security/UserDetailsServiceImpl.java
@@ -2,13 +2,13 @@ package com.dnd.niceteam.security;
 
 import com.dnd.niceteam.member.domain.Member;
 import com.dnd.niceteam.member.repository.MemberRepository;
-import com.dnd.niceteam.security.exception.UsernameNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/dnd/niceteam/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dnd/niceteam/security/jwt/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.dnd.niceteam.security.jwt;
 import com.dnd.niceteam.security.auth.dto.AuthRequestDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -21,8 +22,10 @@ public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFil
 
     private final ObjectMapper objectMapper;
 
-    public JwtAuthenticationFilter(ObjectMapper objectMapper) {
-        super(DEFAULT_ANT_PATH_REQUEST_MATCHER);
+    public JwtAuthenticationFilter(
+            JwtTokenProvider jwtTokenProvider, AuthenticationManager authenticationManager, ObjectMapper objectMapper) {
+        super(DEFAULT_ANT_PATH_REQUEST_MATCHER, authenticationManager);
+        setAuthenticationSuccessHandler(new JwtAuthenticationSuccessHandler(jwtTokenProvider, objectMapper));
         this.objectMapper = objectMapper;
     }
 

--- a/src/main/java/com/dnd/niceteam/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dnd/niceteam/security/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.dnd.niceteam.security.jwt;
 
+import com.dnd.niceteam.member.repository.MemberRepository;
 import com.dnd.niceteam.security.auth.dto.AuthRequestDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpMethod;
@@ -23,9 +24,11 @@ public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFil
     private final ObjectMapper objectMapper;
 
     public JwtAuthenticationFilter(
-            JwtTokenProvider jwtTokenProvider, AuthenticationManager authenticationManager, ObjectMapper objectMapper) {
+            JwtTokenProvider jwtTokenProvider, MemberRepository memberRepository,
+            AuthenticationManager authenticationManager, ObjectMapper objectMapper) {
         super(DEFAULT_ANT_PATH_REQUEST_MATCHER, authenticationManager);
-        setAuthenticationSuccessHandler(new JwtAuthenticationSuccessHandler(jwtTokenProvider, objectMapper));
+        setAuthenticationSuccessHandler(new JwtAuthenticationSuccessHandler(
+                jwtTokenProvider, memberRepository, objectMapper));
         this.objectMapper = objectMapper;
     }
 

--- a/src/main/java/com/dnd/niceteam/security/jwt/JwtAuthenticationSuccessHandler.java
+++ b/src/main/java/com/dnd/niceteam/security/jwt/JwtAuthenticationSuccessHandler.java
@@ -1,12 +1,16 @@
 package com.dnd.niceteam.security.jwt;
 
 import com.dnd.niceteam.common.dto.ApiResult;
+import com.dnd.niceteam.member.domain.Member;
+import com.dnd.niceteam.member.repository.MemberRepository;
 import com.dnd.niceteam.security.auth.dto.AuthResponseDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -18,15 +22,21 @@ public class JwtAuthenticationSuccessHandler implements AuthenticationSuccessHan
 
     private final JwtTokenProvider jwtTokenProvider;
 
+    private final MemberRepository memberRepository;
+
     private final ObjectMapper objectMapper;
 
     @Override
+    @Transactional
     public void onAuthenticationSuccess(
             HttpServletRequest request, HttpServletResponse response, Authentication authentication)
             throws IOException, ServletException {
         String username = authentication.getName();
         String accessToken = jwtTokenProvider.createAccessToken(username);
         String refreshToken = jwtTokenProvider.createRefreshToken(username);
+        Member member = memberRepository.findOneByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("username = " + username));
+        member.setRefreshToken(refreshToken);
         AuthResponseDto.TokenInfo tokenDto = new AuthResponseDto.TokenInfo();
         tokenDto.setAccessToken(accessToken);
         tokenDto.setRefreshToken(refreshToken);

--- a/src/main/java/com/dnd/niceteam/security/jwt/JwtLogoutHandler.java
+++ b/src/main/java/com/dnd/niceteam/security/jwt/JwtLogoutHandler.java
@@ -1,0 +1,40 @@
+package com.dnd.niceteam.security.jwt;
+
+import com.dnd.niceteam.member.domain.Member;
+import com.dnd.niceteam.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@RequiredArgsConstructor
+public class JwtLogoutHandler implements LogoutHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        String token = resolveToken(request);
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            String username = jwtTokenProvider.getSubject(token);
+            Member member = memberRepository.findOneByUsername(username)
+                    .orElseThrow(() -> new UsernameNotFoundException("username = " + username));
+            member.setRefreshToken(null);
+        }
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(JwtTokenProvider.TOKEN_PREFIX)) {
+            return bearerToken.substring(JwtTokenProvider.TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/dnd/niceteam/security/jwt/JwtLogoutSuccessHandler.java
+++ b/src/main/java/com/dnd/niceteam/security/jwt/JwtLogoutSuccessHandler.java
@@ -1,0 +1,28 @@
+package com.dnd.niceteam.security.jwt;
+
+import com.dnd.niceteam.common.dto.ApiResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException, ServletException {
+        ApiResult<Void> result = ApiResult.<Void>success().build();
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getWriter(), result);
+    }
+}

--- a/src/main/java/com/dnd/niceteam/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dnd/niceteam/security/jwt/JwtTokenProvider.java
@@ -98,4 +98,8 @@ public class JwtTokenProvider {
         UserDetails userDetails = userDetailsService.loadUserByUsername(usernameFromToken);
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
+
+    public String getSubject(String token) {
+        return jwtParser.parseClaimsJws(token).getBody().getSubject();
+    }
 }

--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -41,7 +41,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
# 구현 내용/방법

> 간단하게 구현한 내용과 방법에 대한 설명

- JWT 인증 필터들 \@Bean 빈 생성 메서드를 통해 빈 등록 및 의존성 주입
- JWT 로그인 성공 시 디비의 refresh token 갱신 누락 수정
- JWT 로그아웃 구성
- 논의했던 패키지 관련 정리는 아직 진행하지 않았으며, 도메인들을 생성하며 정리하면 될 것 같습니다.

# 리뷰 필요

> 나중에 다시 고민해야할 내용이 있는 내용  
> 없을 경우 작성 X
> 있을 경우 작성 후 이슈 남기고 해당 PR 링크

- 논의했던 대로 \@Component 를 통해서 빈 등록을 진행했는데 실패했습니다. 몇몇 객체는 해당 방법으로 되는 것으로 보입니다만, `JwtAuthenticationFilter` 를 해당 방법으로 빈 등록하자 `@WebMvcTest` 가 깨졌고(`@SpringBootTest`는 정상 작동) 등록되어 있는 다른 JWT 관련 빈 들도 찾지 못하는 것으로 보입니다. 현재 `@WebMvcTest` 는 문서 작성용으로 만든 테스트 메서드인 `CommonDocsControllerTest` 에만 붙어있지만 추후 개발을 진행하며 다른 곳에서도 사용될 수 있기 때문에 `@WebMvcTest` 가 정상적으로 작동하는 메서드 방식의 빈 등록으로 하였습니다.
  - `@Component` 방식의 빈등록을 하며 `@WebMvcTest` 를 사용하려면 아래 링크와 같이 테스트에서도 직접 빈들을 주입해주거나 하나하나 목 객체를 생성해주어야 하는 것으로 보입니다.
    - https://peachberry0318.tistory.com/32
  - 빈 등록에서 어떤 차이로 인해 이런 문제가 발생하는지 정확하게 파악하지는 못 했으며 혹시 조언을 주실 수 있으시면 말씀해주시면 감사드리겠습니다.
- 윤지님이 구성해주신 로그아웃 로직 SecurityFilter 에서 처리되도록 구성해보았는데 한번 검토해주시고, 되돌리는 것이 좋아 보이면 revert 하겠습니다.

