### PR TITLE
feature/#17 이메일 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    implementation 'com.amazonaws:aws-java-sdk-ses'
+
     runtimeOnly 'mysql:mysql-connector-java'
     testRuntimeOnly 'com.h2database:h2'
 

--- a/src/docs/asciidoc/email-auth.adoc
+++ b/src/docs/asciidoc/email-auth.adoc
@@ -15,3 +15,7 @@
 operation::email-auth-send[snippets='http-request,request-fields,http-response,response-fields']
 
 
+[[email-auth-check]]
+== 이메일 인증번호 확인
+
+operation::email-auth-check[snippets='http-request,request-fields,http-response,response-fields-data']

--- a/src/docs/asciidoc/email-auth.adoc
+++ b/src/docs/asciidoc/email-auth.adoc
@@ -1,0 +1,17 @@
+= Email Authentication
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+:operation-http-request-title: Example request
+:operation-http-response-title: Example response
+
+
+[[email-auth-send]]
+== 이메인 인증번호 전송
+
+operation::email-auth-send[snippets='http-request,request-fields,http-response,response-fields']
+
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -8,8 +8,9 @@
 :operation-http-request-title: Example request
 :operation-http-response-title: Example response
 
-.API Domain
+== API Domain
 - xref:auth.adoc[Authentication]
+- xref:email-auth.adoc[Email Authentication]
 
 
 == HTTP Method

--- a/src/main/java/com/dnd/niceteam/common/Domain.java
+++ b/src/main/java/com/dnd/niceteam/common/Domain.java
@@ -6,4 +6,5 @@ public enum Domain {
     ACCOUNT,
     MEMBER,
     UNIVERSITY,
+    EMAIL_AUTH,
 }

--- a/src/main/java/com/dnd/niceteam/common/Domain.java
+++ b/src/main/java/com/dnd/niceteam/common/Domain.java
@@ -5,4 +5,5 @@ public enum Domain {
     AUTH,
     ACCOUNT,
     MEMBER,
+    UNIVERSITY,
 }

--- a/src/main/java/com/dnd/niceteam/domain/emailauth/EmailAuthRepository.java
+++ b/src/main/java/com/dnd/niceteam/domain/emailauth/EmailAuthRepository.java
@@ -2,5 +2,9 @@ package com.dnd.niceteam.domain.emailauth;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long> {
+
+    Optional<EmailAuth> findByEmail(String email);
 }

--- a/src/main/java/com/dnd/niceteam/domain/emailauth/EmailAuthRepository.java
+++ b/src/main/java/com/dnd/niceteam/domain/emailauth/EmailAuthRepository.java
@@ -2,9 +2,5 @@ package com.dnd.niceteam.domain.emailauth;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
-public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long> {
-
-    Optional<EmailAuth> findByEmail(String email);
+public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long>, EmailAuthRepositoryCustom {
 }

--- a/src/main/java/com/dnd/niceteam/domain/emailauth/EmailAuthRepositoryCustom.java
+++ b/src/main/java/com/dnd/niceteam/domain/emailauth/EmailAuthRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.dnd.niceteam.domain.emailauth;
+
+
+import java.util.Optional;
+
+public interface EmailAuthRepositoryCustom {
+
+    Optional<EmailAuth> findLatestByEmail(String email);
+}

--- a/src/main/java/com/dnd/niceteam/domain/emailauth/EmailAuthRepositoryCustomImpl.java
+++ b/src/main/java/com/dnd/niceteam/domain/emailauth/EmailAuthRepositoryCustomImpl.java
@@ -1,0 +1,23 @@
+package com.dnd.niceteam.domain.emailauth;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.dnd.niceteam.domain.emailauth.QEmailAuth.*;
+
+@RequiredArgsConstructor
+public class EmailAuthRepositoryCustomImpl implements EmailAuthRepositoryCustom {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public Optional<EmailAuth> findLatestByEmail(String email) {
+        return Optional.ofNullable(query
+                .selectFrom(emailAuth)
+                .where(emailAuth.email.eq(email))
+                .orderBy(emailAuth.createdDate.desc())
+                .fetchFirst());
+    }
+}

--- a/src/main/java/com/dnd/niceteam/domain/emailauth/exception/EmailAuthNotFoundException.java
+++ b/src/main/java/com/dnd/niceteam/domain/emailauth/exception/EmailAuthNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dnd.niceteam.domain.emailauth.exception;
+
+import com.dnd.niceteam.error.exception.BusinessException;
+import com.dnd.niceteam.error.exception.ErrorCode;
+
+public class EmailAuthNotFoundException extends BusinessException {
+
+    public EmailAuthNotFoundException(String message) {
+        super(ErrorCode.EMAIL_AUTH_NOT_FOUND, message);
+    }
+}

--- a/src/main/java/com/dnd/niceteam/domain/university/UniversityRepository.java
+++ b/src/main/java/com/dnd/niceteam/domain/university/UniversityRepository.java
@@ -2,5 +2,9 @@ package com.dnd.niceteam.domain.university;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UniversityRepository extends JpaRepository<University, Long> {
+
+    Optional<University> findByName(String name);
 }

--- a/src/main/java/com/dnd/niceteam/domain/university/exception/InvalidEmailDomainException.java
+++ b/src/main/java/com/dnd/niceteam/domain/university/exception/InvalidEmailDomainException.java
@@ -1,0 +1,11 @@
+package com.dnd.niceteam.domain.university.exception;
+
+import com.dnd.niceteam.error.exception.BusinessException;
+import com.dnd.niceteam.error.exception.ErrorCode;
+
+public class InvalidEmailDomainException extends BusinessException {
+
+    public InvalidEmailDomainException(String message) {
+        super(ErrorCode.INVALID_EMAIL_DOMAIN, message);
+    }
+}

--- a/src/main/java/com/dnd/niceteam/domain/university/exception/UniversityNotFoundException.java
+++ b/src/main/java/com/dnd/niceteam/domain/university/exception/UniversityNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dnd.niceteam.domain.university.exception;
+
+import com.dnd.niceteam.error.exception.BusinessException;
+import com.dnd.niceteam.error.exception.ErrorCode;
+
+public class UniversityNotFoundException extends BusinessException {
+
+    public UniversityNotFoundException(String message) {
+        super(ErrorCode.UNIVERSITY_NOT_FOUND, message);
+    }
+}

--- a/src/main/java/com/dnd/niceteam/emailauth/config/EmailConfig.java
+++ b/src/main/java/com/dnd/niceteam/emailauth/config/EmailConfig.java
@@ -1,0 +1,25 @@
+package com.dnd.niceteam.emailauth.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EmailConfig {
+
+    @Bean
+    public AmazonSimpleEmailService amazonSimpleEmailService(
+            @Value("${aws.ses.access-key}") String accessKey, @Value("${aws.ses.secret-key}") String secretKey) {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        AWSStaticCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(credentials);
+        return AmazonSimpleEmailServiceClientBuilder.standard()
+                .withCredentials(credentialsProvider)
+                .withRegion(Regions.AP_NORTHEAST_2)
+                .build();
+    }
+}

--- a/src/main/java/com/dnd/niceteam/emailauth/controller/EmailAuthController.java
+++ b/src/main/java/com/dnd/niceteam/emailauth/controller/EmailAuthController.java
@@ -1,6 +1,8 @@
 package com.dnd.niceteam.emailauth.controller;
 
 import com.dnd.niceteam.common.dto.ApiResult;
+import com.dnd.niceteam.emailauth.dto.EmailAuthKeyCheckRequestDto;
+import com.dnd.niceteam.emailauth.dto.EmailAuthKeyCheckResponseDto;
 import com.dnd.niceteam.emailauth.dto.EmailAuthKeySendRequestDto;
 import com.dnd.niceteam.emailauth.service.EmailAuthService;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +25,13 @@ public class EmailAuthController {
     public ResponseEntity<ApiResult<Void>> emailAuthKeySend(@Valid @RequestBody EmailAuthKeySendRequestDto requestDto) {
         emailAuthService.sendEmailAuthKey(requestDto);
         return ResponseEntity.ok(ApiResult.<Void>success().build());
+    }
+
+    @PostMapping("/check")
+    public ResponseEntity<ApiResult<EmailAuthKeyCheckResponseDto>> emailAuthKeyCheck(
+            @Valid @RequestBody EmailAuthKeyCheckRequestDto requestDto) {
+        EmailAuthKeyCheckResponseDto responseDto = emailAuthService.checkEmailAuthKey(requestDto);
+        ApiResult<EmailAuthKeyCheckResponseDto> apiResult = ApiResult.success(responseDto);
+        return ResponseEntity.ok(apiResult);
     }
 }

--- a/src/main/java/com/dnd/niceteam/emailauth/controller/EmailAuthController.java
+++ b/src/main/java/com/dnd/niceteam/emailauth/controller/EmailAuthController.java
@@ -1,0 +1,27 @@
+package com.dnd.niceteam.emailauth.controller;
+
+import com.dnd.niceteam.common.dto.ApiResult;
+import com.dnd.niceteam.emailauth.dto.EmailAuthKeySendRequestDto;
+import com.dnd.niceteam.emailauth.service.EmailAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RequestMapping("/email-auth")
+@RestController
+@RequiredArgsConstructor
+public class EmailAuthController {
+
+    private final EmailAuthService emailAuthService;
+
+    @PostMapping("/send")
+    public ResponseEntity<ApiResult<Void>> emailAuthKeySend(@Valid @RequestBody EmailAuthKeySendRequestDto requestDto) {
+        emailAuthService.sendEmailAuthKey(requestDto);
+        return ResponseEntity.ok(ApiResult.<Void>success().build());
+    }
+}

--- a/src/main/java/com/dnd/niceteam/emailauth/dto/EmailAuthKeyCheckRequestDto.java
+++ b/src/main/java/com/dnd/niceteam/emailauth/dto/EmailAuthKeyCheckRequestDto.java
@@ -1,0 +1,17 @@
+package com.dnd.niceteam.emailauth.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+
+@Data
+public class EmailAuthKeyCheckRequestDto {
+
+    @Email
+    @NotEmpty
+    private String email;
+
+    @NotEmpty
+    private String authKey;
+}

--- a/src/main/java/com/dnd/niceteam/emailauth/dto/EmailAuthKeyCheckResponseDto.java
+++ b/src/main/java/com/dnd/niceteam/emailauth/dto/EmailAuthKeyCheckResponseDto.java
@@ -1,0 +1,11 @@
+package com.dnd.niceteam.emailauth.dto;
+
+import lombok.Data;
+
+@Data
+public class EmailAuthKeyCheckResponseDto {
+
+    private String email;
+
+    private Boolean authenticated;
+}

--- a/src/main/java/com/dnd/niceteam/emailauth/dto/EmailAuthKeySendRequestDto.java
+++ b/src/main/java/com/dnd/niceteam/emailauth/dto/EmailAuthKeySendRequestDto.java
@@ -1,0 +1,17 @@
+package com.dnd.niceteam.emailauth.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+
+@Data
+public class EmailAuthKeySendRequestDto {
+
+    @Email
+    @NotEmpty
+    private String email;
+
+    @NotEmpty
+    private String univName;
+}

--- a/src/main/java/com/dnd/niceteam/emailauth/service/EmailAuthKeyCreator.java
+++ b/src/main/java/com/dnd/niceteam/emailauth/service/EmailAuthKeyCreator.java
@@ -1,0 +1,23 @@
+package com.dnd.niceteam.emailauth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Component
+@RequiredArgsConstructor
+public class EmailAuthKeyCreator {
+
+    public static final int KEY_SIZE = 6;
+
+    private final Random random = new Random();
+
+    public String createEmailAuthKey() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < KEY_SIZE; i++) {
+            sb.append(random.nextInt(10));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/dnd/niceteam/emailauth/service/EmailAuthService.java
+++ b/src/main/java/com/dnd/niceteam/emailauth/service/EmailAuthService.java
@@ -1,0 +1,62 @@
+package com.dnd.niceteam.emailauth.service;
+
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.amazonaws.services.simpleemail.model.*;
+import com.dnd.niceteam.domain.emailauth.EmailAuth;
+import com.dnd.niceteam.domain.emailauth.EmailAuthRepository;
+import com.dnd.niceteam.domain.university.University;
+import com.dnd.niceteam.domain.university.UniversityRepository;
+import com.dnd.niceteam.domain.university.exception.InvalidEmailDomainException;
+import com.dnd.niceteam.domain.university.exception.UniversityNotFoundException;
+import com.dnd.niceteam.emailauth.dto.EmailAuthKeySendRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmailAuthService {
+
+    private static final String EMAIL_AUTH_SUBJECT = "[팀구] 회원가입 이메일 인증";
+
+    private final AmazonSimpleEmailService emailService;
+
+    private final EmailAuthRepository emailAuthRepository;
+
+    private final UniversityRepository universityRepository;
+
+    private final EmailAuthKeyCreator keyCreator;
+
+    @Transactional
+    public void sendEmailAuthKey(EmailAuthKeySendRequestDto requestDto) {
+        University university = universityRepository.findByName(requestDto.getUnivName())
+                .orElseThrow(() -> new UniversityNotFoundException("University name = " + requestDto.getUnivName()));
+        String email = requestDto.getEmail();
+        if (isInvalidEmailDomain(university, email)) {
+            throw new InvalidEmailDomainException("email = " + email);
+        }
+        EmailAuth emailAuth = emailAuthRepository.save(EmailAuth.builder()
+                .email(email)
+                .authKey(keyCreator.createEmailAuthKey())
+                .build());
+        Content content = new Content()
+                .withData("인증번호: " + emailAuth.getAuthKey())
+                .withCharset(StandardCharsets.UTF_8.name());
+        Message message = new Message()
+                .withSubject(new Content(EMAIL_AUTH_SUBJECT).withCharset(StandardCharsets.UTF_8.name()))
+                .withBody(new Body(content));
+        SendEmailRequest sendEmailRequest = new SendEmailRequest()
+                .withDestination(new Destination(List.of(emailAuth.getEmail())))
+                .withSource("nice2meetteam@gmail.com")
+                .withMessage(message);
+        emailService.sendEmail(sendEmailRequest);
+    }
+
+    private boolean isInvalidEmailDomain(University university, String email) {
+        return !email.endsWith(university.getEmailDomain());
+    }
+}

--- a/src/main/java/com/dnd/niceteam/emailauth/service/EmailAuthService.java
+++ b/src/main/java/com/dnd/niceteam/emailauth/service/EmailAuthService.java
@@ -43,17 +43,21 @@ public class EmailAuthService {
                 .email(email)
                 .authKey(keyCreator.createEmailAuthKey())
                 .build());
+        SendEmailRequest sendEmailRequest = createSendEmailRequest(emailAuth);
+        emailService.sendEmail(sendEmailRequest);
+    }
+
+    private SendEmailRequest createSendEmailRequest(EmailAuth emailAuth) {
         Content content = new Content()
                 .withData("인증번호: " + emailAuth.getAuthKey())
                 .withCharset(StandardCharsets.UTF_8.name());
         Message message = new Message()
                 .withSubject(new Content(EMAIL_AUTH_SUBJECT).withCharset(StandardCharsets.UTF_8.name()))
                 .withBody(new Body(content));
-        SendEmailRequest sendEmailRequest = new SendEmailRequest()
+        return new SendEmailRequest()
                 .withDestination(new Destination(List.of(emailAuth.getEmail())))
                 .withSource("nice2meetteam@gmail.com")
                 .withMessage(message);
-        emailService.sendEmail(sendEmailRequest);
     }
 
     private boolean isInvalidEmailDomain(University university, String email) {

--- a/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
@@ -25,6 +25,8 @@ public enum ErrorCode {
 
     UNIVERSITY_NOT_FOUND(UNIVERSITY, SC_NOT_FOUND, "존재하지 않는 대학교입니다."),
     INVALID_EMAIL_DOMAIN(UNIVERSITY, SC_BAD_REQUEST, "적절하지 않은 이메일 도메인입니다."),
+
+    EMAIL_AUTH_NOT_FOUND(EMAIL_AUTH, SC_NOT_FOUND, "인증번호 발급을 하지 않은 상태입니다."),
     ;
 
     private final Domain domain;

--- a/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
@@ -22,6 +22,9 @@ public enum ErrorCode {
     REFRESH_TOKEN_IS_NULL_ERROR(AUTH, SC_UNAUTHORIZED, "로그아웃 상태입니다."),
 
     MEMBER_NOT_FOUND(MEMBER, SC_NOT_FOUND, "존재하지 않는 회원입니다."),
+
+    UNIVERSITY_NOT_FOUND(UNIVERSITY, SC_NOT_FOUND, "존재하지 않는 대학교입니다."),
+    INVALID_EMAIL_DOMAIN(UNIVERSITY, SC_BAD_REQUEST, "적절하지 않은 이메일 도메인입니다."),
     ;
 
     private final Domain domain;

--- a/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
@@ -31,7 +31,8 @@ public class SecurityConfig {
     };
 
     private static final String[] POST_PERMITTED_URLS = {
-            "/auth/reissue"
+            "/auth/reissue",
+            "/email-auth/send"
     };
 
     @Bean

--- a/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/niceteam/security/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
 
     private static final String[] POST_PERMITTED_URLS = {
             "/auth/reissue",
-            "/email-auth/send"
+            "/email-auth/send",
+            "/email-auth/check"
     };
 
     @Bean

--- a/src/main/resources/application-mail.yml
+++ b/src/main/resources/application-mail.yml
@@ -1,0 +1,15 @@
+aws:
+  ses:
+    access-key: ${aws.ses.access_key}
+    secret-key: ${aws.ses.secret_key}
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+
+aws:
+  ses:
+    access-key: fake-aws-ses-access-key
+    secret-key: fake-aws-ses-secret-key

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,14 +4,15 @@ spring:
   profiles:
     active: local
     group:
-      local: db, jwt
-      dev: db, jwt
+      local: db, jwt, mail
+      dev: db, jwt, mail
 aws:
   paramstore:
     name: niceteam
     enabled: true
     prefix: /config
     profile-separator: _
+
 ---
 spring:
   config:

--- a/src/test/java/com/dnd/niceteam/domain/emailauth/EmailAuthRepositoryTest.java
+++ b/src/test/java/com/dnd/niceteam/domain/emailauth/EmailAuthRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.dnd.niceteam.domain.emailauth;
+
+import com.dnd.niceteam.common.TestJpaConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Transactional
+@Import(TestJpaConfig.class)
+class EmailAuthRepositoryTest {
+
+    @Autowired
+    private EmailAuthRepository emailAuthRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    void findLatestByEmail() {
+        // given
+        emailAuthRepository.save(EmailAuth.builder()
+                .email("test@teamgoo.com")
+                .authKey("123456")
+                .build());
+        emailAuthRepository.save(EmailAuth.builder()
+                .email("test@teamgoo.com")
+                .authKey("234567")
+                .build());
+        emailAuthRepository.save(EmailAuth.builder()
+                .email("test@teamgoo.com")
+                .authKey("345678")
+                .build());
+        em.flush();
+        em.clear();
+
+        // when
+        EmailAuth emailAuth = emailAuthRepository.findLatestByEmail("test@teamgoo.com")
+                .orElseThrow(() -> new IllegalArgumentException("인증번호가 발급되지 않음."));
+        assertThat(emailAuth.getAuthKey()).isEqualTo("345678");
+    }
+}

--- a/src/test/java/com/dnd/niceteam/emailauth/controller/EmailAuthControllerTest.java
+++ b/src/test/java/com/dnd/niceteam/emailauth/controller/EmailAuthControllerTest.java
@@ -1,0 +1,75 @@
+package com.dnd.niceteam.emailauth.controller;
+
+import com.dnd.niceteam.common.RestDocsConfig;
+import com.dnd.niceteam.emailauth.dto.EmailAuthKeySendRequestDto;
+import com.dnd.niceteam.emailauth.service.EmailAuthService;
+import com.dnd.niceteam.security.SecurityConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(RestDocsConfig.class)
+@AutoConfigureRestDocs
+//@SpringBootTest
+//@AutoConfigureMockMvc
+@WebMvcTest(controllers = EmailAuthController.class, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class) })
+class EmailAuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private EmailAuthService emailAuthService;
+
+    @Test
+    @WithMockUser
+    @DisplayName("이메일 인증번호 전송")
+    void emailAuthKeySend_Success() throws Exception {
+        // given
+        EmailAuthKeySendRequestDto requestDto = new EmailAuthKeySendRequestDto();
+        requestDto.setEmail("teat@teamgoo.ac.kr");
+        requestDto.setUnivName("팀구대학교");
+
+        // expected
+        mockMvc.perform(post("/email-auth/send").with(csrf())
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andDo(document("email-auth-send",
+                        requestFields(
+                                fieldWithPath("email").description("인증할 이메일")
+                                        .attributes(key("constraint").value("해당 대학교의 이메일 도메인과 일치")),
+                                fieldWithPath("univName").description("대학교 이름")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").description("요청 성공 -> 인증번호 해당 이메일로 발송")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/dnd/niceteam/emailauth/service/EmailAuthServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/emailauth/service/EmailAuthServiceTest.java
@@ -4,12 +4,16 @@ import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
 import com.dnd.niceteam.common.TestJpaConfig;
 import com.dnd.niceteam.domain.emailauth.EmailAuth;
 import com.dnd.niceteam.domain.emailauth.EmailAuthRepository;
+import com.dnd.niceteam.domain.emailauth.exception.EmailAuthNotFoundException;
 import com.dnd.niceteam.domain.university.University;
 import com.dnd.niceteam.domain.university.UniversityRepository;
 import com.dnd.niceteam.domain.university.exception.InvalidEmailDomainException;
 import com.dnd.niceteam.domain.university.exception.UniversityNotFoundException;
+import com.dnd.niceteam.emailauth.dto.EmailAuthKeyCheckRequestDto;
+import com.dnd.niceteam.emailauth.dto.EmailAuthKeyCheckResponseDto;
 import com.dnd.niceteam.emailauth.dto.EmailAuthKeySendRequestDto;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -58,6 +62,7 @@ class EmailAuthServiceTest {
     }
 
     @Test
+    @DisplayName("이메일 인증번호 요청 - 성공")
     void sendEmailAuthKey_Success() {
         // given
         universityRepository.save(University.builder()
@@ -76,12 +81,13 @@ class EmailAuthServiceTest {
         emailAuthService.sendEmailAuthKey(requestDto);
 
         // then
-        EmailAuth emailAuth = emailAuthRepository.findByEmail("test@teamgoo.com")
+        EmailAuth emailAuth = emailAuthRepository.findLatestByEmail("test@teamgoo.com")
                 .orElseThrow(() -> new IllegalArgumentException("Email not found."));
         assertThat(emailAuth.getAuthKey()).isEqualTo("123456");
     }
 
     @Test
+    @DisplayName("이메일 인증번호 요청 -> 없는 대학교 이름으로 - 실패")
     void sendEmailAuthKey_NotFoundUniv_ThenFail() {
         // given
         universityRepository.save(University.builder()
@@ -102,6 +108,7 @@ class EmailAuthServiceTest {
     }
 
     @Test
+    @DisplayName("이메일 인증번호 요청 -> 일치하지 않는 이메일 도메인 - 실패")
     void sendEmailAuthKey_InvalidEmail_ThenFail() {
         // given
         universityRepository.save(University.builder()
@@ -119,5 +126,80 @@ class EmailAuthServiceTest {
         // expected
         assertThatThrownBy(() -> emailAuthService.sendEmailAuthKey(requestDto))
                 .isInstanceOf(InvalidEmailDomainException.class);
+    }
+
+    @Test
+    @DisplayName("이메일 인증번호 확인 - 성공")
+    void checkEmailAuthKey_Success() {
+        // given
+        emailAuthRepository.save(EmailAuth.builder()
+                .email("test@teamgoo.com")
+                .authKey("123456")
+                .build());
+        EmailAuthKeyCheckRequestDto requestDto = new EmailAuthKeyCheckRequestDto();
+        requestDto.setEmail("test@teamgoo.com");
+        requestDto.setAuthKey("123456");
+        em.flush();
+        em.clear();
+
+        // when
+        EmailAuthKeyCheckResponseDto responseDto = emailAuthService.checkEmailAuthKey(requestDto);
+
+        // then
+        assertThat(responseDto.getEmail()).isEqualTo("test@teamgoo.com");
+        assertThat(responseDto.getAuthenticated()).isTrue();
+
+        EmailAuth emailAuth = emailAuthRepository.findLatestByEmail("test@teamgoo.com")
+                .orElseThrow(() -> new IllegalArgumentException("인증번호가 발급되지 않음."));
+        assertThat(emailAuth.getEmail()).isEqualTo("test@teamgoo.com");
+        assertThat(emailAuth.getAuthKey()).isEqualTo("123456");
+        assertThat(emailAuth.getAuthenticated()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이메일 인증번호 확인 -> 인증번호가 발급되지 않은 이메일 - 실패")
+    void checkEmailAuthKey_NotFoundEmailAuth_ThenFail() {
+        // given
+        emailAuthRepository.save(EmailAuth.builder()
+                .email("test@teamgoo.com")
+                .authKey("123456")
+                .build());
+        EmailAuthKeyCheckRequestDto requestDto = new EmailAuthKeyCheckRequestDto();
+        requestDto.setEmail("notfound@teamgoo.com");
+        requestDto.setAuthKey("123456");
+        em.flush();
+        em.clear();
+
+        // expected
+        assertThatThrownBy(() -> emailAuthService.checkEmailAuthKey(requestDto))
+                .isInstanceOf(EmailAuthNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("이메일 인증번호 확인 -> 인증번호 불일치 - 성공")
+    void checkEmailAuthKey_IncorrectKey_Success() {
+        // given
+        emailAuthRepository.save(EmailAuth.builder()
+                .email("test@teamgoo.com")
+                .authKey("123456")
+                .build());
+        EmailAuthKeyCheckRequestDto requestDto = new EmailAuthKeyCheckRequestDto();
+        requestDto.setEmail("test@teamgoo.com");
+        requestDto.setAuthKey("000000");
+        em.flush();
+        em.clear();
+
+        // when
+        EmailAuthKeyCheckResponseDto responseDto = emailAuthService.checkEmailAuthKey(requestDto);
+
+        // then
+        assertThat(responseDto.getEmail()).isEqualTo("test@teamgoo.com");
+        assertThat(responseDto.getAuthenticated()).isFalse();
+
+        EmailAuth emailAuth = emailAuthRepository.findLatestByEmail("test@teamgoo.com")
+                .orElseThrow(() -> new IllegalArgumentException("인증번호가 발급되지 않음."));
+        assertThat(emailAuth.getEmail()).isEqualTo("test@teamgoo.com");
+        assertThat(emailAuth.getAuthKey()).isEqualTo("123456");
+        assertThat(emailAuth.getAuthenticated()).isFalse();
     }
 }

--- a/src/test/java/com/dnd/niceteam/emailauth/service/EmailAuthServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/emailauth/service/EmailAuthServiceTest.java
@@ -1,0 +1,123 @@
+package com.dnd.niceteam.emailauth.service;
+
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.dnd.niceteam.common.TestJpaConfig;
+import com.dnd.niceteam.domain.emailauth.EmailAuth;
+import com.dnd.niceteam.domain.emailauth.EmailAuthRepository;
+import com.dnd.niceteam.domain.university.University;
+import com.dnd.niceteam.domain.university.UniversityRepository;
+import com.dnd.niceteam.domain.university.exception.InvalidEmailDomainException;
+import com.dnd.niceteam.domain.university.exception.UniversityNotFoundException;
+import com.dnd.niceteam.emailauth.dto.EmailAuthKeySendRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@DataJpaTest
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@Import(TestJpaConfig.class)
+@Transactional
+class EmailAuthServiceTest {
+
+    private EmailAuthService emailAuthService;
+
+    @Autowired
+    private EmailAuthRepository emailAuthRepository;
+
+    @Autowired
+    private UniversityRepository universityRepository;
+
+    @Mock
+    private AmazonSimpleEmailService mockEmailService;
+
+    @Mock
+    private EmailAuthKeyCreator mockKeyCreator;
+
+    @Autowired
+    private EntityManager em;
+
+    @BeforeEach
+    void setup() {
+        emailAuthService = new EmailAuthService(
+                mockEmailService, emailAuthRepository, universityRepository, mockKeyCreator);
+    }
+
+    @Test
+    void sendEmailAuthKey_Success() {
+        // given
+        universityRepository.save(University.builder()
+                .name("팀구대학교")
+                .emailDomain("teamgoo.com")
+                .build());
+        EmailAuthKeySendRequestDto requestDto = new EmailAuthKeySendRequestDto();
+        requestDto.setEmail("test@teamgoo.com");
+        requestDto.setUnivName("팀구대학교");
+        given(mockKeyCreator.createEmailAuthKey()).willReturn("123456");
+
+        em.flush();
+        em.clear();
+
+        // when
+        emailAuthService.sendEmailAuthKey(requestDto);
+
+        // then
+        EmailAuth emailAuth = emailAuthRepository.findByEmail("test@teamgoo.com")
+                .orElseThrow(() -> new IllegalArgumentException("Email not found."));
+        assertThat(emailAuth.getAuthKey()).isEqualTo("123456");
+    }
+
+    @Test
+    void sendEmailAuthKey_NotFoundUniv_ThenFail() {
+        // given
+        universityRepository.save(University.builder()
+                .name("팀구대학교")
+                .emailDomain("teamgoo.com")
+                .build());
+        EmailAuthKeySendRequestDto requestDto = new EmailAuthKeySendRequestDto();
+        requestDto.setEmail("test@teamgoo.com");
+        requestDto.setUnivName("없는대학교");
+        given(mockKeyCreator.createEmailAuthKey()).willReturn("123456");
+
+        em.flush();
+        em.clear();
+
+        // expected
+        assertThatThrownBy(() -> emailAuthService.sendEmailAuthKey(requestDto))
+                .isInstanceOf(UniversityNotFoundException.class);
+    }
+
+    @Test
+    void sendEmailAuthKey_InvalidEmail_ThenFail() {
+        // given
+        universityRepository.save(University.builder()
+                .name("팀구대학교")
+                .emailDomain("teamgoo.com")
+                .build());
+        EmailAuthKeySendRequestDto requestDto = new EmailAuthKeySendRequestDto();
+        requestDto.setEmail("test@invalidemail.com");
+        requestDto.setUnivName("팀구대학교");
+        given(mockKeyCreator.createEmailAuthKey()).willReturn("123456");
+
+        em.flush();
+        em.clear();
+
+        // expected
+        assertThatThrownBy(() -> emailAuthService.sendEmailAuthKey(requestDto))
+                .isInstanceOf(InvalidEmailDomainException.class);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -24,3 +24,8 @@ jwt:
   secret: a2FrYW9jbG91ZHNjaG9vbGxvY2Fsa2FrYW9jbG91ZGMK
   access-token-validity: 3600
   refresh-token-validity: 2592000
+
+aws:
+  ses:
+    access-key: fake-aws-ses-access-key
+    secret-key: fake-aws-ses-secret-key

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
@@ -4,9 +4,9 @@
 {{#fields}}
 |{{path}}
 |{{type}}
+|{{description}}
 |{{#optional}}Y{{/optional}}
 |{{#constraint}} {{.}} {{/constraint}}
-|{{description}}
 
 {{/fields}}
 |===


### PR DESCRIPTION
# 구현 내용/방법

> 간단하게 구현한 내용과 방법에 대한 설명

- 이메일 인증 번호 전송
  - AWS SES 이용
  - 이메일 도메인과 대학교 이름 체크
- 이메일 인증 번호 확인
  - 인증번호 만료기간 5분


# 리뷰 필요

> 나중에 다시 고민해야할 내용이 있는 내용  
> 없을 경우 작성 X
> 있을 경우 작성 후 이슈 남기고 해당 PR 링크

- 

close #17 
