### PR TITLE
Feature/#29 신규 프로젝트 등록 Service 메서드 추가

### DIFF
--- a/src/main/java/com/dnd/niceteam/common/Domain.java
+++ b/src/main/java/com/dnd/niceteam/common/Domain.java
@@ -8,5 +8,7 @@ public enum Domain {
     DEPARTMENT,
     ACCOUNT,
     MEMBER,
-    MEMBER_SCORE
+    MEMBER_SCORE,
+
+    PROJECT
 }

--- a/src/main/java/com/dnd/niceteam/domain/project/ProjectRepository.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/ProjectRepository.java
@@ -1,0 +1,6 @@
+package com.dnd.niceteam.domain.project;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+}

--- a/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
@@ -32,6 +32,9 @@ public enum ErrorCode {
     NOT_AUTHENTICATED_EMAIL(EMAIL_AUTH, SC_BAD_REQUEST, "인증되지 않은 이메일입니다."),
 
     DEPARTMENT_NOT_FOUND(DEPARTMENT, SC_NOT_FOUND, "존재하지 않는 학과입니다."),
+
+    // Project
+    INVALID_PROJECT_DATE(PROJECT, SC_BAD_REQUEST, "프로젝트 기간이 유효하지 않습니다.")
     ;
 
     private final Domain domain;

--- a/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
@@ -34,7 +34,7 @@ public enum ErrorCode {
     DEPARTMENT_NOT_FOUND(DEPARTMENT, SC_NOT_FOUND, "존재하지 않는 학과입니다."),
 
     // Project
-    INVALID_PROJECT_DATE(PROJECT, SC_BAD_REQUEST, "프로젝트 기간이 유효하지 않습니다.")
+    INVALID_PROJECT_SCHEDULE(PROJECT, SC_BAD_REQUEST, "프로젝트 기간이 유효하지 않습니다.")
     ;
 
     private final Domain domain;

--- a/src/main/java/com/dnd/niceteam/project/dto/ProjectRequest.java
+++ b/src/main/java/com/dnd/niceteam/project/dto/ProjectRequest.java
@@ -1,0 +1,33 @@
+package com.dnd.niceteam.project.dto;
+
+import com.dnd.niceteam.domain.project.Project;
+import com.dnd.niceteam.domain.project.ProjectType;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+public interface ProjectRequest {
+
+    @Data
+    class Register {
+
+        private String name;
+
+        private ProjectType type;
+
+        private LocalDateTime startDate;
+
+        private LocalDateTime endDate;
+
+        public Project toEntity() {
+            return Project.builder()
+                    .name(name)
+                    .type(type)
+                    .startDate(startDate)
+                    .endDate(endDate)
+                    .build();
+        }
+
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/project/dto/ProjectResponse.java
+++ b/src/main/java/com/dnd/niceteam/project/dto/ProjectResponse.java
@@ -1,0 +1,54 @@
+package com.dnd.niceteam.project.dto;
+
+import com.dnd.niceteam.domain.project.Project;
+import com.dnd.niceteam.domain.project.ProjectStatus;
+import com.dnd.niceteam.domain.project.ProjectType;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+public interface ProjectResponse {
+
+    @Data
+    class Detail {
+
+        private Long id;
+
+        // Project 상태
+        private String name;
+        private ProjectType type;
+        private ProjectStatus status;
+
+        private LocalDateTime startDate;
+        private LocalDateTime endDate;
+
+        // Auditing 정보
+        private LocalDateTime createdDate;
+        private LocalDateTime lastModifiedDate;
+        private String createdBy;
+        private String lastModifiedBy;
+
+        public static Detail from(Project project) {
+            Detail self = new Detail();
+            self.setId(project.getId());
+
+            // Project 상태
+            self.setName(project.getName());
+            self.setType(project.getType());
+            self.setStatus(project.getStatus());
+
+            self.setStartDate(project.getStartDate());
+            self.setEndDate(project.getEndDate());
+
+            // Auditing 정보
+            self.setCreatedDate(project.getCreatedDate());
+            self.setLastModifiedDate(project.getLastModifiedDate());
+            self.setCreatedBy(project.getCreatedBy());
+            self.setLastModifiedBy(project.getLastModifiedBy());
+
+            return self;
+        }
+
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/project/exception/InvalidProjectSchedule.java
+++ b/src/main/java/com/dnd/niceteam/project/exception/InvalidProjectSchedule.java
@@ -1,0 +1,12 @@
+package com.dnd.niceteam.project.exception;
+
+import com.dnd.niceteam.error.exception.BusinessException;
+import com.dnd.niceteam.error.exception.ErrorCode;
+
+public class InvalidProjectSchedule extends BusinessException {
+
+    public InvalidProjectSchedule(String message) {
+        super(ErrorCode.INVALID_PROJECT_SCHEDULE, message);
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/project/service/ProjectService.java
+++ b/src/main/java/com/dnd/niceteam/project/service/ProjectService.java
@@ -4,9 +4,12 @@ import com.dnd.niceteam.domain.project.Project;
 import com.dnd.niceteam.domain.project.ProjectRepository;
 import com.dnd.niceteam.project.dto.ProjectRequest;
 import com.dnd.niceteam.project.dto.ProjectResponse;
+import com.dnd.niceteam.project.exception.InvalidProjectSchedule;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -14,9 +17,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProjectService {
 
     private final ProjectRepository projectRepository;
-
+    
+    // TODO: 기획 논의 후 startDate, endDate에 @Past, @Future 등의 유효성검사 어노테이션 붙이기
     @Transactional
     public ProjectResponse.Detail registerProject(ProjectRequest.Register request) {
+        LocalDateTime startDate = request.getStartDate();
+        LocalDateTime endDate = request.getEndDate();
+
+        if (endDate.isBefore(startDate)) {
+            throw new InvalidProjectSchedule("startDate = " + startDate + ", endDate = " + endDate);
+        }
+
         Project newProject = projectRepository.save(request.toEntity());
         return ProjectResponse.Detail.from(newProject);
     }

--- a/src/main/java/com/dnd/niceteam/project/service/ProjectService.java
+++ b/src/main/java/com/dnd/niceteam/project/service/ProjectService.java
@@ -1,0 +1,24 @@
+package com.dnd.niceteam.project.service;
+
+import com.dnd.niceteam.domain.project.Project;
+import com.dnd.niceteam.domain.project.ProjectRepository;
+import com.dnd.niceteam.project.dto.ProjectRequest;
+import com.dnd.niceteam.project.dto.ProjectResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+
+    @Transactional
+    public ProjectResponse.Detail registerProject(ProjectRequest.Register request) {
+        Project newProject = projectRepository.save(request.toEntity());
+        return ProjectResponse.Detail.from(newProject);
+    }
+
+}

--- a/src/test/java/com/dnd/niceteam/project/ProjectTestFactory.java
+++ b/src/test/java/com/dnd/niceteam/project/ProjectTestFactory.java
@@ -1,0 +1,27 @@
+package com.dnd.niceteam.project;
+
+import com.dnd.niceteam.domain.project.Project;
+import com.dnd.niceteam.domain.project.ProjectStatus;
+import com.dnd.niceteam.domain.project.ProjectType;
+import com.dnd.niceteam.project.dto.ProjectRequest;
+
+import java.time.LocalDateTime;
+
+public class ProjectTestFactory {
+
+    private static final Long id = 1L;
+    private static final String name = "테스트 프로젝트";
+    private static final ProjectType type = ProjectType.MY_LECTURE;
+    private static final LocalDateTime startDate = LocalDateTime.of(2022, 7, 4, 0, 0);
+    private static final LocalDateTime endDate = LocalDateTime.of(2022, 8, 27, 23, 59);
+
+    public static ProjectRequest.Register createRegisterRequest() {
+        ProjectRequest.Register request = new ProjectRequest.Register();
+        request.setName(name);
+        request.setType(type);
+        request.setStartDate(startDate);
+        request.setEndDate(endDate);
+        return request;
+    }
+
+}

--- a/src/test/java/com/dnd/niceteam/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/project/service/ProjectServiceTest.java
@@ -1,0 +1,54 @@
+package com.dnd.niceteam.project.service;
+
+import com.dnd.niceteam.domain.project.Project;
+import com.dnd.niceteam.domain.project.ProjectRepository;
+import com.dnd.niceteam.project.ProjectTestFactory;
+import com.dnd.niceteam.project.dto.ProjectRequest;
+import com.dnd.niceteam.project.dto.ProjectResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceTest {
+
+    @InjectMocks
+    ProjectService projectService;
+
+    @Mock
+    ProjectRepository projectRepository;
+
+    @DisplayName("신규 프로젝트를 등록한 뒤 저장한 상태값들을 반환합니다.")
+    @Test
+    void registerProject() {
+        // given
+        ProjectRequest.Register request = ProjectTestFactory.createRegisterRequest();
+        Project newProject = request.toEntity();
+
+        // when
+        when(projectRepository.save(any(Project.class))).thenReturn(newProject);
+        ProjectResponse.Detail response = projectService.registerProject(request);
+
+        // then
+        assertAll(
+                () -> assertEquals(response.getId(), newProject.getId()),
+
+                // 프로젝트 상태
+                () -> assertEquals(response.getName(), newProject.getName()),
+                () -> assertEquals(response.getType(), newProject.getType()),
+                () -> assertEquals(response.getStatus(), newProject.getStatus()),
+
+                () -> assertEquals(response.getStartDate(), newProject.getStartDate()),
+                () -> assertEquals(response.getEndDate(), newProject.getEndDate())
+        );
+    }
+
+}


### PR DESCRIPTION
# 구현 내용/방법

- 프로젝트 등록 Service 메서드 추가

  i. 윤지님이 나중에 가져다 쓰실 메서드예요!
  ii. 유효성 어노테이션은 아직 없어요🙅‍♂️
       나중에 디자인팀이랑 정리한 뒤에 한꺼번에 반영하려구요ㅎㅎ

# 리뷰 필요

- ProjectTestFactory의 `static final` 상수들의 케이스를
  카멜 케이스 🐪 vs. 🐍 다른 상수처럼 대문자 스네이크 케이스
  어느 쪽으로 하는 게 나을까요?
  
- 모집글과 동시에 프로젝트를 생성할 때 윤지님이 사용할 메서드인데 아래의 경우 외에 다른 예외 상황이 있을까요?
  1) endDate가 startDate보다 빠를 경우
  2) `미반영` 이미 종료된 프로젝트일 경우 `→ 디자인 팀, 윤지님과 논의 후 반영`
      (등록 시 endDate가 이미 지난 프로젝트)

close #29
