### PR TITLE
fix(Domain): @Builder & @Column 관련 JPA 테이블 생성 버그 수정

### DIFF
--- a/src/main/java/com/dnd/niceteam/domain/applicant/Applicant.java
+++ b/src/main/java/com/dnd/niceteam/domain/applicant/Applicant.java
@@ -11,6 +11,7 @@ import javax.persistence.*;
 
 @Entity
 @Getter
+@Builder
 @SQLDelete(sql = "UPDATE applicant SET use_yn = false WHERE id = ?")
 @Where(clause = "use_yn = true")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/dnd/niceteam/domain/comment/Comment.java
+++ b/src/main/java/com/dnd/niceteam/domain/comment/Comment.java
@@ -11,6 +11,7 @@ import javax.persistence.*;
 
 @Entity
 @Getter
+@Builder
 @SQLDelete(sql = "UPDATE comment SET use_yn = false WHERE id = ?")
 @Where(clause = "use_yn = true")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/LectureRecruiting.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/LectureRecruiting.java
@@ -1,7 +1,10 @@
 package com.dnd.niceteam.domain.recruiting;
 
 import com.dnd.niceteam.domain.department.Department;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.HashSet;
@@ -9,6 +12,7 @@ import java.util.Set;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @DiscriminatorValue("CLASS")
@@ -22,7 +26,7 @@ public class LectureRecruiting extends Recruiting{
     private String professor;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @Column(nullable = false)
+    @JoinColumn(nullable = false)
     private Department department;
 
     @Builder.Default

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/Recruiting.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/Recruiting.java
@@ -8,7 +8,6 @@ import com.dnd.niceteam.domain.common.BaseEntity;
 import com.dnd.niceteam.domain.member.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
@@ -19,7 +18,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Entity
-@Builder
 @SQLDelete(sql = "UPDATE recruiting SET use_yn = false WHERE id = ?")
 @Where(clause = "use_yn = true")
 @AllArgsConstructor


### PR DESCRIPTION
# 구현 내용/방법

- class의 멤버 변수에 `@Builder.Default`가 있는 Entity들에 `@Builder` 어노테이션을 추가했어요!
- abstract class에 있는 `@Builder` 어노테이션을 제거해 이를 상속한 Entity의 `@Builder`와 충돌을 일으키지 않도록 수정했어요 :D

close #36
