### PR TITLE
Feature/#22 투표 Aggregate Entity 추가

### DIFF
--- a/src/main/java/com/dnd/niceteam/domain/vote/Vote.java
+++ b/src/main/java/com/dnd/niceteam/domain/vote/Vote.java
@@ -1,0 +1,38 @@
+package com.dnd.niceteam.domain.vote;
+
+
+import com.dnd.niceteam.domain.common.BaseEntity;
+import com.dnd.niceteam.domain.project.ProjectMember;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "vote")
+@SQLDelete(sql = "UPDATE vote SET use_yn = false WHERE id = ?")
+@Where(clause = "use_yn = true")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Vote extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "vote_id")
+    private Long id;
+
+    @Column(name = "choice", nullable = false)
+    private Boolean choice;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "vote_group_id", nullable = false)
+    private VoteGroup voteGroup;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_member_id", nullable = false)
+    private ProjectMember projectMember;
+
+}

--- a/src/main/java/com/dnd/niceteam/domain/vote/VoteGroup.java
+++ b/src/main/java/com/dnd/niceteam/domain/vote/VoteGroup.java
@@ -2,7 +2,10 @@ package com.dnd.niceteam.domain.vote;
 
 import com.dnd.niceteam.domain.common.BaseEntity;
 import com.dnd.niceteam.domain.project.Project;
-import lombok.*;
+import io.jsonwebtoken.lang.Assert;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -10,29 +13,30 @@ import javax.persistence.*;
 
 @Entity
 @Getter
-@Builder
 @Table(name = "vote_group")
 @SQLDelete(sql = "UPDATE vote_group SET use_yn = false WHERE id = ?")
 @Where(clause = "use_yn = true")
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class VoteGroup extends BaseEntity {
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "type")
+public abstract class VoteGroup extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "vote_group_id")
     private Long id;
 
-    @Column(name = "type", nullable = false)
-    @Enumerated(EnumType.STRING)
-    private VoteType type;
-
     @Column(name = "complete", nullable = false)
-    @Builder.Default
     private Boolean complete = false;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "project_id", nullable = false)
     private Project project;
+
+    public VoteGroup(Project project) {
+        Assert.notNull(project, "project는 필수 값입니다.");
+
+        this.project = project;
+    }
 
 }

--- a/src/main/java/com/dnd/niceteam/domain/vote/VoteGroup.java
+++ b/src/main/java/com/dnd/niceteam/domain/vote/VoteGroup.java
@@ -1,0 +1,38 @@
+package com.dnd.niceteam.domain.vote;
+
+import com.dnd.niceteam.domain.common.BaseEntity;
+import com.dnd.niceteam.domain.project.Project;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "vote_group")
+@SQLDelete(sql = "UPDATE vote_group SET use_yn = false WHERE id = ?")
+@Where(clause = "use_yn = true")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VoteGroup extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "vote_group_id")
+    private Long id;
+
+    @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private VoteType type;
+
+    @Column(name = "complete", nullable = false)
+    @Builder.Default
+    private Boolean complete = false;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+}

--- a/src/main/java/com/dnd/niceteam/domain/vote/VoteGroupToCompleteProject.java
+++ b/src/main/java/com/dnd/niceteam/domain/vote/VoteGroupToCompleteProject.java
@@ -1,0 +1,26 @@
+package com.dnd.niceteam.domain.vote;
+
+import com.dnd.niceteam.domain.project.Project;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue("COMPLETE_PROJECT")
+@OnDelete(action = OnDeleteAction.CASCADE)
+public class VoteGroupToCompleteProject extends VoteGroup {
+
+    @Builder
+    public VoteGroupToCompleteProject(Project project) {
+        super(project);
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/domain/vote/VoteGroupToExpel.java
+++ b/src/main/java/com/dnd/niceteam/domain/vote/VoteGroupToExpel.java
@@ -1,0 +1,35 @@
+package com.dnd.niceteam.domain.vote;
+
+import com.dnd.niceteam.domain.project.Project;
+import com.dnd.niceteam.domain.project.ProjectMember;
+import io.jsonwebtoken.lang.Assert;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue("EXPEL")
+@OnDelete(action = OnDeleteAction.CASCADE)
+public class VoteGroupToExpel extends VoteGroup {
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_member_id", nullable = false)
+    private ProjectMember projectMember;
+
+    @Builder
+    public VoteGroupToExpel(Project project, ProjectMember projectMember) {
+        super(project);
+
+        Assert.notNull(projectMember, "projectMember는 필수 값입니다.");
+
+        this.projectMember = projectMember;
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/domain/vote/VoteType.java
+++ b/src/main/java/com/dnd/niceteam/domain/vote/VoteType.java
@@ -1,0 +1,16 @@
+package com.dnd.niceteam.domain.vote;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum VoteType {
+
+    PROJECT_COMPLETE("팀플 완료 투표")
+    , KICK("내보내기 투표")
+    ;
+
+    private final String kor;
+
+}


### PR DESCRIPTION
# 구현 내용/방법

- 투표 그룹 abstract class 추가
- 투표 그룹을 상속한 팀플 완료, 내보내기 Entity 추가
- 찬반 투표 여부를 기록할 투표 Entity 추가

# 리뷰 필요

- ✅ 투표 그룹 상속 방식

    `SINGLE_TABLE` 으로 ERD와 다르게 변경됐어요!

- 🔡 투표 Entity의 `choice` 속성 네이밍

    팀원들의 찬반 여부를 기록할 속성인데 네이밍이 적절한가요?

- 🔡 팀플 완료 투표 그룹 네이밍

    `VoteGroupToCompleteProject`로 엄청 긴데 짧고 좋은 이름 생각나시면 추천해주세요ㅎㅎ

close #22
