### PR TITLE
Feature/#40 add member review

### DIFF
--- a/src/main/java/com/dnd/niceteam/common/Domain.java
+++ b/src/main/java/com/dnd/niceteam/common/Domain.java
@@ -10,5 +10,6 @@ public enum Domain {
     MEMBER,
     MEMBER_SCORE,
 
-    PROJECT
+    PROJECT,
+    PROJECT_MEMBER
 }

--- a/src/main/java/com/dnd/niceteam/domain/project/Project.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/Project.java
@@ -1,20 +1,25 @@
 package com.dnd.niceteam.domain.project;
 
 import com.dnd.niceteam.domain.common.BaseEntity;
-import lombok.*;
+import com.dnd.niceteam.domain.member.Member;
+import io.jsonwebtoken.lang.Assert;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Getter
-@Builder
 @Table(name = "project")
 @SQLDelete(sql = "UPDATE project SET use_yn = false WHERE id = ?")
 @Where(clause = "use_yn = true")
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Project extends BaseEntity {
 
@@ -38,7 +43,32 @@ public class Project extends BaseEntity {
 
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
-    @Builder.Default
     private ProjectStatus status = ProjectStatus.NOT_STARTED;
+
+    @OneToMany(mappedBy = "project")
+    private Set<ProjectMember> projectMembers = new HashSet<>();
+
+    @Builder
+    private Project(String name, ProjectType type, LocalDate startDate, LocalDate endDate, ProjectStatus status) {
+        Assert.hasText(name, "name은 필수 값입니다.");
+        Assert.notNull(type, "type은 필수 값입니다.");
+        Assert.notNull(startDate, "startDate는 필수 값입니다.");
+        Assert.notNull(endDate, "endDate는 필수 값입니다.");
+        Assert.notNull(name, "status는 필수 값입니다.");
+
+        this.name = name;
+        this.type = type;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
+    }
+
+    public void addMember(Member member) {
+        ProjectMember projectMember = ProjectMember.builder()
+                .project(this)
+                .member(member)
+                .build();
+        projectMembers.add(projectMember);
+    }
 
 }

--- a/src/main/java/com/dnd/niceteam/domain/project/ProjectMember.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/ProjectMember.java
@@ -2,7 +2,10 @@ package com.dnd.niceteam.domain.project;
 
 import com.dnd.niceteam.domain.common.BaseEntity;
 import com.dnd.niceteam.domain.member.Member;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -10,11 +13,9 @@ import javax.persistence.*;
 
 @Entity
 @Getter
-@Builder
 @Table(name = "project_member")
 @SQLDelete(sql = "UPDATE project_member SET use_yn = false WHERE id = ?")
 @Where(clause = "use_yn = true")
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProjectMember extends BaseEntity {
 
@@ -24,7 +25,6 @@ public class ProjectMember extends BaseEntity {
     private Long id;
 
     @Column(name = "expelled", nullable = false)
-    @Builder.Default
     private Boolean expelled = false;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -34,5 +34,20 @@ public class ProjectMember extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    /**
+     * 양방향 관계 및<br>
+     * Project 변경이 발생할 수 없는<br>
+     * ProjectMember의 특징을 고려해<br>
+     * Project에서만 생성할 수 있도록 스코프를 제한했습니다.
+     * 
+     * @param project 등록할 프로젝트
+     * @param member 프로젝트에 등록할 회원
+     */
+    @Builder(access = AccessLevel.PACKAGE)
+    private ProjectMember(Project project, Member member) {
+        this.project = project;
+        this.member = member;
+    }
 
 }

--- a/src/main/java/com/dnd/niceteam/domain/project/ProjectMemberRepository.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/ProjectMemberRepository.java
@@ -1,0 +1,11 @@
+package com.dnd.niceteam.domain.project;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
+
+    List<ProjectMember> findByProject(Project project);
+
+}

--- a/src/main/java/com/dnd/niceteam/domain/review/MemberReview.java
+++ b/src/main/java/com/dnd/niceteam/domain/review/MemberReview.java
@@ -1,7 +1,11 @@
 package com.dnd.niceteam.domain.review;
 
 import com.dnd.niceteam.domain.common.BaseEntity;
-import lombok.*;
+import com.dnd.niceteam.domain.project.ProjectMember;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -11,11 +15,9 @@ import java.util.Set;
 
 @Entity
 @Getter
-@Builder
 @Table(name = "member_review")
 @SQLDelete(sql = "UPDATE member_review SET use_yn = false WHERE id = ?")
 @Where(clause = "use_yn = true")
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberReview extends BaseEntity {
 
@@ -33,8 +35,30 @@ public class MemberReview extends BaseEntity {
     @Column(name = "skipped", nullable = false)
     private Boolean skipped;
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reviewer_id", nullable = false)
+    private ProjectMember reviewer;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reviewee_id", nullable = false)
+    private ProjectMember reviewee;
+
     @OneToMany(mappedBy = "memberReview", cascade = CascadeType.REMOVE)
-    @Builder.Default
     private Set<MemberReviewTag> memberReviewTags = new HashSet<>();
+
+    @Builder
+    private MemberReview(
+            Integer participationScore,
+            Integer hopeToReunionScore,
+            ProjectMember reviewer,
+            ProjectMember reviewee,
+            Set<MemberReviewTag> memberReviewTags
+    ) {
+        this.participationScore = participationScore;
+        this.hopeToReunionScore = hopeToReunionScore;
+        this.reviewer = reviewer;
+        this.reviewee = reviewee;
+        this.memberReviewTags = memberReviewTags;
+    }
 
 }

--- a/src/main/java/com/dnd/niceteam/domain/review/MemberReviewRepository.java
+++ b/src/main/java/com/dnd/niceteam/domain/review/MemberReviewRepository.java
@@ -1,0 +1,6 @@
+package com.dnd.niceteam.domain.review;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberReviewRepository extends JpaRepository<MemberReview, Long> {
+}

--- a/src/main/java/com/dnd/niceteam/domain/review/MemberReviewTag.java
+++ b/src/main/java/com/dnd/niceteam/domain/review/MemberReviewTag.java
@@ -1,7 +1,10 @@
 package com.dnd.niceteam.domain.review;
 
 import com.dnd.niceteam.domain.common.BaseEntity;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -10,7 +13,6 @@ import java.util.Objects;
 
 @Entity
 @Getter
-@Builder
 @Table(name = "member_review_tag")
 @SQLDelete(sql = "UPDATE member_review_tag SET use_yn = false WHERE id = ?")
 @Where(clause = "use_yn = true")
@@ -30,6 +32,14 @@ public class MemberReviewTag extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_review_id", nullable = false)
     private MemberReview memberReview;
+
+    public MemberReviewTag(String tagName) {
+        this.tag = MemberReviewTagName.getByKor(tagName);
+    }
+
+    public MemberReviewTag(MemberReviewTagName tag) {
+        this.tag = tag;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/com/dnd/niceteam/domain/review/MemberReviewTagName.java
+++ b/src/main/java/com/dnd/niceteam/domain/review/MemberReviewTagName.java
@@ -3,12 +3,31 @@ package com.dnd.niceteam.domain.review;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Getter
 @RequiredArgsConstructor
 public enum MemberReviewTagName {
 
+    책임감_굿("책임감 굿")
+    , 마감을_칼같이("마감을 칼같이")
+    , 분위기_메이커("분위기 메이커")
+    , 시간매너_끝판왕("시간매너 끝판왕")
     ;
 
-    private String kor;
+    private final String kor;
+
+    public static final Map<String, MemberReviewTagName> map = new HashMap<>();
+
+    static {
+        for (MemberReviewTagName tagName : MemberReviewTagName.values()) {
+            map.put(tagName.getKor(), tagName);
+        }
+    }
+
+    public static MemberReviewTagName getByKor(String tagName) {
+        return map.get(tagName);
+    }
 
 }

--- a/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
@@ -34,7 +34,9 @@ public enum ErrorCode {
     DEPARTMENT_NOT_FOUND(DEPARTMENT, SC_NOT_FOUND, "존재하지 않는 학과입니다."),
 
     // Project
-    INVALID_PROJECT_SCHEDULE(PROJECT, SC_BAD_REQUEST, "프로젝트 기간이 유효하지 않습니다.")
+    INVALID_PROJECT_SCHEDULE(PROJECT, SC_BAD_REQUEST, "프로젝트 기간이 유효하지 않습니다."),
+    PROJECT_NOT_FOUND(PROJECT, SC_NOT_FOUND, "존재하지 않는 프로젝트입니다."),
+    PROJECT_MEMBER_NOT_FUND(PROJECT_MEMBER, SC_NOT_FOUND, "존재하지 않는 팀원입니다.")
     ;
 
     private final Domain domain;

--- a/src/main/java/com/dnd/niceteam/project/exception/ProjectMemberNotFoundException.java
+++ b/src/main/java/com/dnd/niceteam/project/exception/ProjectMemberNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dnd.niceteam.project.exception;
+
+import com.dnd.niceteam.error.exception.BusinessException;
+import com.dnd.niceteam.error.exception.ErrorCode;
+
+public class ProjectMemberNotFoundException extends BusinessException {
+
+    public ProjectMemberNotFoundException(String message) {
+        super(ErrorCode.PROJECT_MEMBER_NOT_FUND, message);
+    }
+}

--- a/src/main/java/com/dnd/niceteam/project/exception/ProjectNotFoundException.java
+++ b/src/main/java/com/dnd/niceteam/project/exception/ProjectNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dnd.niceteam.project.exception;
+
+import com.dnd.niceteam.error.exception.BusinessException;
+import com.dnd.niceteam.error.exception.ErrorCode;
+
+public class ProjectNotFoundException extends BusinessException {
+
+    public ProjectNotFoundException(String message) {
+        super(ErrorCode.PROJECT_NOT_FOUND, message);
+    }
+}

--- a/src/main/java/com/dnd/niceteam/review/controller/MemberReviewController.java
+++ b/src/main/java/com/dnd/niceteam/review/controller/MemberReviewController.java
@@ -1,0 +1,31 @@
+package com.dnd.niceteam.review.controller;
+
+import com.dnd.niceteam.common.dto.ApiResult;
+import com.dnd.niceteam.domain.member.Member;
+import com.dnd.niceteam.review.dto.MemberReviewRequest;
+import com.dnd.niceteam.review.service.MemberReviewService;
+import com.dnd.niceteam.security.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/member-reviews")
+@RequiredArgsConstructor
+public class MemberReviewController {
+
+    private final MemberReviewService memberReviewService;
+
+    @PostMapping
+    public ResponseEntity<ApiResult<Void>> memberReviewAdd(MemberReviewRequest.Add request, @CurrentMember Member currentMember) {
+        memberReviewService.addMemberReview(request, currentMember);
+        ApiResult<Void> apiResult = ApiResult.<Void>success().build();
+        return ResponseEntity.status(HttpStatus.CREATED).body(apiResult);
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/review/dto/MemberReviewRequest.java
+++ b/src/main/java/com/dnd/niceteam/review/dto/MemberReviewRequest.java
@@ -1,0 +1,48 @@
+package com.dnd.niceteam.review.dto;
+
+import com.dnd.niceteam.domain.project.ProjectMember;
+import com.dnd.niceteam.domain.review.MemberReview;
+import com.dnd.niceteam.domain.review.MemberReviewTag;
+import lombok.Data;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import java.util.List;
+import java.util.Set;
+
+public interface MemberReviewRequest {
+
+    @Data
+    class Add {
+
+        @Positive
+        @Max(5)
+        @NotNull
+        private Integer participationScore;
+
+        @Positive
+        @Max(5)
+        @NotNull
+        private Integer hopeToReunionScore;
+
+        @NotNull
+        private List<String> tagNames;
+
+        @NotNull
+        private Long projectId;
+        @NotNull
+        private Long revieweeId;
+
+        public MemberReview toEntity(ProjectMember reviewer, ProjectMember reviewee, Set<MemberReviewTag> memberReviewTags) {
+            return MemberReview.builder()
+                    .participationScore(participationScore)
+                    .hopeToReunionScore(hopeToReunionScore)
+                    .reviewer(reviewer)
+                    .reviewee(reviewee)
+                    .memberReviewTags(memberReviewTags)
+                    .build();
+        }
+
+    }
+}

--- a/src/main/java/com/dnd/niceteam/review/service/MemberReviewService.java
+++ b/src/main/java/com/dnd/niceteam/review/service/MemberReviewService.java
@@ -1,0 +1,61 @@
+package com.dnd.niceteam.review.service;
+
+import com.dnd.niceteam.domain.member.Member;
+import com.dnd.niceteam.domain.project.Project;
+import com.dnd.niceteam.domain.project.ProjectMember;
+import com.dnd.niceteam.domain.project.ProjectMemberRepository;
+import com.dnd.niceteam.domain.project.ProjectRepository;
+import com.dnd.niceteam.domain.review.MemberReview;
+import com.dnd.niceteam.domain.review.MemberReviewRepository;
+import com.dnd.niceteam.domain.review.MemberReviewTag;
+import com.dnd.niceteam.project.exception.ProjectMemberNotFoundException;
+import com.dnd.niceteam.project.exception.ProjectNotFoundException;
+import com.dnd.niceteam.review.dto.MemberReviewRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberReviewService {
+
+    private final MemberReviewRepository memberReviewRepository;
+    private final ProjectRepository projectRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+
+    @Transactional
+    public MemberReview addMemberReview(MemberReviewRequest.Add request, Member currentMember) {
+        Project project = findProject(request.getProjectId());
+        List<ProjectMember> projectMembers = projectMemberRepository.findByProject(project);
+
+        ProjectMember reviewer = findProjectMemberFrom(projectMembers, currentMember.getId());
+        ProjectMember reviewee = findProjectMemberFrom(projectMembers, request.getRevieweeId());
+        Set<MemberReviewTag> tags = getMemberReviewTags(request.getTagNames());
+
+        MemberReview newMemberReview = request.toEntity(reviewer, reviewee, tags);
+        return memberReviewRepository.save(newMemberReview);
+    }
+
+    private Project findProject(Long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(() -> new ProjectNotFoundException("id = " + projectId));
+    }
+
+    private ProjectMember findProjectMemberFrom(List<ProjectMember> projectMembers, Long memberId) {
+        return projectMembers.stream()
+                .filter(projectMember -> Objects.equals(projectMember.getMember().getId(), memberId))
+                .findAny()
+                .orElseThrow(() -> new ProjectMemberNotFoundException("memberId = " + memberId));
+    }
+
+    private Set<MemberReviewTag> getMemberReviewTags(List<String> tagNames) {
+        return tagNames.stream().map(MemberReviewTag::new).collect(Collectors.toSet());
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/security/CurrentMember.java
+++ b/src/main/java/com/dnd/niceteam/security/CurrentMember.java
@@ -1,0 +1,12 @@
+package com.dnd.niceteam.security;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.*;
+
+@Target({ ElementType.PARAMETER, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal
+public @interface CurrentMember {
+}

--- a/src/test/java/com/dnd/niceteam/project/ProjectTestFactory.java
+++ b/src/test/java/com/dnd/niceteam/project/ProjectTestFactory.java
@@ -1,6 +1,5 @@
 package com.dnd.niceteam.project;
 
-import com.dnd.niceteam.domain.project.Project;
 import com.dnd.niceteam.domain.project.ProjectType;
 import com.dnd.niceteam.project.dto.ProjectRequest;
 

--- a/src/test/java/com/dnd/niceteam/review/MemberReviewTestFactory.java
+++ b/src/test/java/com/dnd/niceteam/review/MemberReviewTestFactory.java
@@ -1,0 +1,28 @@
+package com.dnd.niceteam.review;
+
+import com.dnd.niceteam.domain.review.MemberReviewTagName;
+import com.dnd.niceteam.review.dto.MemberReviewRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MemberReviewTestFactory {
+
+    public static MemberReviewRequest.Add getMemberReviewRequest(Long revieweeId) {
+        MemberReviewRequest.Add request = new MemberReviewRequest.Add();
+        List<String> tagNames = new ArrayList<>(List.of(MemberReviewTagName.책임감_굿.getKor(), MemberReviewTagName.마감을_칼같이.getKor()));
+
+        request.setParticipationScore(5);
+        request.setHopeToReunionScore(4);
+        request.setProjectId(1L);
+        request.setRevieweeId(revieweeId);
+        request.setTagNames(tagNames);
+
+        return request;
+    }
+
+    public static MemberReviewRequest.Add getMemberReviewRequest() {
+        return getMemberReviewRequest(2L);
+    }
+
+}

--- a/src/test/java/com/dnd/niceteam/review/controller/MemberReviewControllerTest.java
+++ b/src/test/java/com/dnd/niceteam/review/controller/MemberReviewControllerTest.java
@@ -1,0 +1,79 @@
+package com.dnd.niceteam.review.controller;
+
+import com.dnd.niceteam.common.RestDocsConfig;
+import com.dnd.niceteam.review.MemberReviewTestFactory;
+import com.dnd.niceteam.review.dto.MemberReviewRequest;
+import com.dnd.niceteam.review.service.MemberReviewService;
+import com.dnd.niceteam.security.SecurityConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(RestDocsConfig.class)
+@AutoConfigureRestDocs
+@WebMvcTest(
+        controllers = MemberReviewController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+        })
+class MemberReviewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MemberReviewService memberReviewService;
+
+    @Test
+    @WithMockUser
+    @DisplayName("팀원 후기 등록")
+    void addMemberReview() throws Exception {
+        // given
+        MemberReviewRequest.Add request = MemberReviewTestFactory.getMemberReviewRequest();
+
+        // then
+        mockMvc.perform(
+                post("/member-reviews")
+                        .with(csrf())
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                ).andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andDo(
+                        document("add-member-review",
+                            requestFields(
+                                    fieldWithPath("participationScore").description("참여도 점수"),
+                                    fieldWithPath("hopeToReunionScore").description("재팀원 희망 점수"),
+                                    fieldWithPath("tagNames").description("후기 태그 목록"),
+                                    fieldWithPath("projectId").description("프로젝트 식별자"),
+                                    fieldWithPath("revieweeId").description("피평가자 아이디")
+                            )
+                        )
+                );
+    }
+
+}

--- a/src/test/java/com/dnd/niceteam/review/service/MemberReviewServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/review/service/MemberReviewServiceTest.java
@@ -1,0 +1,72 @@
+package com.dnd.niceteam.review.service;
+
+import com.dnd.niceteam.domain.member.Member;
+import com.dnd.niceteam.domain.project.Project;
+import com.dnd.niceteam.domain.project.ProjectMember;
+import com.dnd.niceteam.domain.project.ProjectMemberRepository;
+import com.dnd.niceteam.domain.project.ProjectRepository;
+import com.dnd.niceteam.domain.review.MemberReview;
+import com.dnd.niceteam.domain.review.MemberReviewRepository;
+import com.dnd.niceteam.review.MemberReviewTestFactory;
+import com.dnd.niceteam.review.dto.MemberReviewRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberReviewServiceTest {
+
+    @InjectMocks
+    MemberReviewService memberReviewService;
+
+    @Mock
+    MemberReviewRepository memberReviewRepository;
+    @Mock
+    ProjectRepository projectRepository;
+    @Mock
+    ProjectMemberRepository projectMemberRepository;
+
+    @DisplayName("팀원 후기 등록")
+    @Test
+    void addMemberReview() {
+        // given
+        Long currentMemberId = 1L;
+        Long revieweeId = 2L;
+        MemberReviewRequest.Add request = MemberReviewTestFactory.getMemberReviewRequest(revieweeId);
+
+        Member currentMember = mock(Member.class);
+        when(currentMember.getId()).thenReturn(currentMemberId);
+
+        Project project = mock(Project.class);
+        when(projectRepository.findById(anyLong())).thenReturn(Optional.of(project));
+
+        List<ProjectMember> projectMembers = getMockProjectMembers(List.of(currentMemberId, revieweeId));
+        when(projectMemberRepository.findByProject(project)).thenReturn(projectMembers);
+
+        // when
+        memberReviewService.addMemberReview(request, currentMember);
+
+        // then
+        verify(memberReviewRepository).save(any(MemberReview.class));
+    }
+
+    private List<ProjectMember> getMockProjectMembers(List<Long> ids) {
+        return ids.stream().map(id -> {
+            ProjectMember projectMember = mock(ProjectMember.class, RETURNS_DEEP_STUBS);
+            when(projectMember.getMember().getId()).thenReturn(id);
+            return projectMember;
+        }).collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION
# 구현 내용/방법

- 로그인된 회원 정보를 가져오기 위해 Security 모듈에 @CurrentMember 어노테이션을 추가했어요 😀
- Project, ProjectMember, MemberReview Entity의 `@Builder` 및 생성자 스코프를 변경했어요
- 팀원 후기 작성 API와 관련된 Controller, Service 메서드를 추가했어요

# 리뷰 필요

- @Cho-D-YoungRae b71be10d1172a02ce2f5b8208763969ecd281c5d 커밋의  [MemberReviewControllerTest.java](https://github.com/dnd-side-project/dnd-7th-2-backend/commit/b71be10d1172a02ce2f5b8208763969ecd281c5d#diff-34f8f0ba7f9b8f8b79e1130a219121f2012e9c8ecd5ff4fedd547184ea15c126) RestDocs 테스트 코드 작성했는데 빠진 부분 없을까요? 한 번 봐주실 수 있어요?

- [MemberReviewRequest.java](https://github.com/dnd-side-project/dnd-7th-2-backend/compare/feature/%2340_Add_Member_Review?expand=1#diff-23961ab19de997503e0a35c8d4f3dd61c52b8c606b31b5e712ddc8095e0b5ec9) 유효성검사 어노테이션 적당한가요?

close #40
