### PR TITLE
bugfix: 7기 2조의 수준은 어디까지?! 페이지네이션의 오류를 찾아라!

### DIFF
--- a/src/main/java/com/dnd/niceteam/common/dto/Pagination.java
+++ b/src/main/java/com/dnd/niceteam/common/dto/Pagination.java
@@ -36,7 +36,7 @@ public class Pagination<T> {
 
         // 연산된 값
         int pageWithFullContent = totalCount / perSize;
-        int pageWithLackContent = totalCount % perSize == 0 ? 1 : 0;
+        int pageWithLackContent = totalCount % perSize == 0 ? 0 : 1;
         this.totalPages = pageWithFullContent + pageWithLackContent;
 
         this.prev = page > 1;

--- a/src/test/java/com/dnd/niceteam/common/dto/PaginationTest.java
+++ b/src/test/java/com/dnd/niceteam/common/dto/PaginationTest.java
@@ -18,7 +18,7 @@ class PaginationTest {
         int perSize = 5;
         int totalCount = 113;
 
-        int totalPages = totalCount / perSize + (totalCount % perSize == 0 ? 1 : 0);
+        int totalPages = totalCount / perSize + 1;
 
         String content1 = "테스트 내용 1";
         String content2 = "테스트 내용 2";


### PR DESCRIPTION
# 버그 내용

DND 7기 2️⃣조는 과연, 페이지네이션 속에 숨겨둔 오류를 찾아낼 수 있을까요..?!?!

전체 페이지 = 총 데이터 개수 / 페이지 사이즈 + 나머지가 없으면 1 페이지를 더하는
**totalCount / perSize + totalCount % pageSize == 0 ? 1 : 0** 이라는 말도 안 되는 저세상 페이지네이션...! 💭(☠ x 100)

저 같아도 안 믿었을 것 같은 얘긴데,

절대 실수로 0 : 1을 1 : 0으로 바꿔서 적은 게 아니라 🙅‍♂️

2️⃣조 백엔드 실력이 궁금하잖아요?
대체 이 사람들의 실력은 어디까지인가? 🙊
궁금해서 참을 수가 없었어요! 🤤

영래님은 이거, 안 알아보고 참을 수 있어요???
윤지님은 참을 수 있어요???????????????????????
네에ㅔ❓❓⁉


## 버그 상황 설명

사실은 제가 버그입니다
제 실력이 버그입니다

안녕하세요 오늘부터 양버그라고ㅂ ㅜㄹ러주새요

> P.S. 버그 찾아오신 윤지님 리스펙트해요 👍


## 재현 방법

1. 정신 머리를 놓고 온다
2. 코드 걱정보다 담날 출근 걱정을 더 많이 한다
3. 에라 모르겠다 자자! 하고 PR 날린다
4. 뻔뻔하게 실수 안 한 척 한다
5. 뜬금없이 사과하고 자책한다

close #60