### PR TITLE
Feature/#55 팀원 후기 건너뛰기 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Macbook ###
 .DS_Store
+
+### 테스트 ###
+data.sql

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mockito:mockito-inline'                                 // Mockito로 static 메서드를 테스트하기 위한 라이브러리
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/src/docs/asciidoc/member-review.adoc
+++ b/src/docs/asciidoc/member-review.adoc
@@ -1,0 +1,21 @@
+= Member Review (팀원 후기)
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+:operation-http-request-title: Example request
+:operation-http-response-title: Example response
+
+
+[[add-member-review]]
+== 팀원 후기 등록
+
+operation::skip-member-review[snippets='http-request,request-parameters,http-response,response-fields-data']
+
+
+[[skip-member-review]]
+== 팀원 후기 건너뛰기
+
+operation::skip-member-review[snippets='http-request,request-parameters,http-response,response-fields-data']

--- a/src/main/java/com/dnd/niceteam/domain/project/Project.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/Project.java
@@ -6,6 +6,7 @@ import io.jsonwebtoken.lang.Assert;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -42,7 +43,8 @@ public abstract class Project extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ProjectStatus status = ProjectStatus.NOT_STARTED;
 
-    @OneToMany(mappedBy = "project")
+    @BatchSize(size = 100)
+    @OneToMany(mappedBy = "project", fetch = FetchType.EAGER)
     private Set<ProjectMember> projectMembers = new HashSet<>();
 
     protected Project(String name, LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/com/dnd/niceteam/domain/project/Project.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/Project.java
@@ -44,7 +44,7 @@ public abstract class Project extends BaseEntity {
     private ProjectStatus status = ProjectStatus.NOT_STARTED;
 
     @BatchSize(size = 100)
-    @OneToMany(mappedBy = "project", fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "project")
     private Set<ProjectMember> projectMembers = new HashSet<>();
 
     protected Project(String name, LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/com/dnd/niceteam/domain/project/ProjectRepository.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/ProjectRepository.java
@@ -2,5 +2,5 @@ package com.dnd.niceteam.domain.project;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LectureProjectRepository extends JpaRepository<LectureProject, Long> {
+public interface ProjectRepository<T extends Project> extends JpaRepository<T, Long> {
 }

--- a/src/main/java/com/dnd/niceteam/domain/review/MemberReview.java
+++ b/src/main/java/com/dnd/niceteam/domain/review/MemberReview.java
@@ -2,6 +2,7 @@ package com.dnd.niceteam.domain.review;
 
 import com.dnd.niceteam.domain.common.BaseEntity;
 import com.dnd.niceteam.domain.project.ProjectMember;
+import io.jsonwebtoken.lang.Assert;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,14 +27,14 @@ public class MemberReview extends BaseEntity {
     @Column(name = "member_review_id")
     private Long id;
 
-    @Column(name = "participation_score", columnDefinition = "TINYINT UNSIGNED", nullable = false)
+    @Column(name = "participation_score")
     private Integer participationScore;
 
-    @Column(name = "team_again_score", columnDefinition = "TINYINT UNSIGNED", nullable = false)
+    @Column(name = "team_again_score")
     private Integer teamAgainScore;
 
     @Column(name = "skipped", nullable = false)
-    private Boolean skipped;
+    private Boolean skipped = false;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "reviewer_id", nullable = false)
@@ -54,11 +55,31 @@ public class MemberReview extends BaseEntity {
             ProjectMember reviewee,
             Set<MemberReviewTag> memberReviewTags
     ) {
+
+        Assert.notNull(reviewer, "reviewer는 필수 값입니다.");
+        Assert.notNull(reviewee, "reviewee는 필수 값입니다.");
+
+
         this.participationScore = participationScore;
         this.teamAgainScore = teamAgainScore;
         this.reviewer = reviewer;
         this.reviewee = reviewee;
         this.memberReviewTags = memberReviewTags;
+    }
+
+    public static MemberReview skip(ProjectMember reviewer, ProjectMember reviewee) {
+        MemberReview memberReview = MemberReview.builder()
+                .reviewer(reviewer)
+                .reviewee(reviewee)
+                .build();
+
+        memberReview.setSkipped(true);
+
+        return memberReview;
+    }
+
+    private void setSkipped(Boolean skipped) {
+        this.skipped = skipped;
     }
 
 }

--- a/src/main/java/com/dnd/niceteam/domain/review/MemberReview.java
+++ b/src/main/java/com/dnd/niceteam/domain/review/MemberReview.java
@@ -29,8 +29,8 @@ public class MemberReview extends BaseEntity {
     @Column(name = "participation_score", columnDefinition = "TINYINT UNSIGNED", nullable = false)
     private Integer participationScore;
 
-    @Column(name = "hope_to_reunion_score", columnDefinition = "TINYINT UNSIGNED", nullable = false)
-    private Integer hopeToReunionScore;
+    @Column(name = "team_again_score", columnDefinition = "TINYINT UNSIGNED", nullable = false)
+    private Integer teamAgainScore;
 
     @Column(name = "skipped", nullable = false)
     private Boolean skipped;
@@ -49,13 +49,13 @@ public class MemberReview extends BaseEntity {
     @Builder
     private MemberReview(
             Integer participationScore,
-            Integer hopeToReunionScore,
+            Integer teamAgainScore,
             ProjectMember reviewer,
             ProjectMember reviewee,
             Set<MemberReviewTag> memberReviewTags
     ) {
         this.participationScore = participationScore;
-        this.hopeToReunionScore = hopeToReunionScore;
+        this.teamAgainScore = teamAgainScore;
         this.reviewer = reviewer;
         this.reviewee = reviewee;
         this.memberReviewTags = memberReviewTags;

--- a/src/main/java/com/dnd/niceteam/member/util/MemberUtils.java
+++ b/src/main/java/com/dnd/niceteam/member/util/MemberUtils.java
@@ -1,0 +1,14 @@
+package com.dnd.niceteam.member.util;
+
+import com.dnd.niceteam.domain.member.Member;
+import com.dnd.niceteam.domain.member.MemberRepositoryCustom;
+import com.dnd.niceteam.domain.member.exception.MemberNotFoundException;
+
+public abstract class MemberUtils {
+
+    public static Member findMemberByEmail(String email, MemberRepositoryCustom memberRepository) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberNotFoundException("email = " + email));
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/member/util/MemberUtils.java
+++ b/src/main/java/com/dnd/niceteam/member/util/MemberUtils.java
@@ -1,14 +1,20 @@
 package com.dnd.niceteam.member.util;
 
 import com.dnd.niceteam.domain.member.Member;
+import com.dnd.niceteam.domain.member.MemberRepository;
 import com.dnd.niceteam.domain.member.MemberRepositoryCustom;
 import com.dnd.niceteam.domain.member.exception.MemberNotFoundException;
 
 public abstract class MemberUtils {
 
-    public static Member findMemberByEmail(String email, MemberRepositoryCustom memberRepository) {
-        return memberRepository.findByEmail(email)
+    public static Member findMemberByEmail(String email, MemberRepositoryCustom memberRepositoryCustom) {
+        return memberRepositoryCustom.findByEmail(email)
                 .orElseThrow(() -> new MemberNotFoundException("email = " + email));
+    }
+
+    public static Member findMemberById(Long id, MemberRepository memberRepository) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new MemberNotFoundException("id = " + id));
     }
 
 }

--- a/src/main/java/com/dnd/niceteam/project/service/LectureProjectService.java
+++ b/src/main/java/com/dnd/niceteam/project/service/LectureProjectService.java
@@ -4,7 +4,7 @@ import com.dnd.niceteam.domain.department.Department;
 import com.dnd.niceteam.domain.department.DepartmentRepository;
 import com.dnd.niceteam.domain.department.exception.DepartmentNotFoundException;
 import com.dnd.niceteam.domain.project.LectureProject;
-import com.dnd.niceteam.domain.project.LectureProjectRepository;
+import com.dnd.niceteam.domain.project.ProjectRepository;
 import com.dnd.niceteam.domain.project.LectureTime;
 import com.dnd.niceteam.project.dto.LectureProjectRequest;
 import com.dnd.niceteam.project.dto.LectureProjectResponse;
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class LectureProjectService {
 
-    private final LectureProjectRepository lectureProjectRepository;
+    private final ProjectRepository<LectureProject> projectRepository;
     private final DepartmentRepository departmentRepository;
     
     // TODO: 기획 논의 후 startDate, endDate에 @Past, @Future 등의 유효성검사 어노테이션 붙이기
@@ -42,7 +42,7 @@ public class LectureProjectService {
 
         Set<LectureTime> lectureTimes = mapLectureTimeFromRequest(request.getLectureTimes());
 
-        LectureProject newLectureProject = lectureProjectRepository.save(
+        LectureProject newLectureProject = projectRepository.save(
                 request.toEntity(department, lectureTimes)
         );
         return LectureProjectResponse.Detail.from(newLectureProject);

--- a/src/main/java/com/dnd/niceteam/review/controller/MemberReviewController.java
+++ b/src/main/java/com/dnd/niceteam/review/controller/MemberReviewController.java
@@ -1,14 +1,14 @@
 package com.dnd.niceteam.review.controller;
 
 import com.dnd.niceteam.common.dto.ApiResult;
-import com.dnd.niceteam.domain.member.Member;
 import com.dnd.niceteam.review.dto.MemberReviewRequest;
 import com.dnd.niceteam.review.service.MemberReviewService;
-import com.dnd.niceteam.security.CurrentMember;
+import com.dnd.niceteam.security.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,7 +22,9 @@ public class MemberReviewController {
     private final MemberReviewService memberReviewService;
 
     @PostMapping
-    public ResponseEntity<ApiResult<Void>> memberReviewAdd(MemberReviewRequest.Add request, @CurrentMember Member currentMember) {
+    public ResponseEntity<ApiResult<Void>> memberReviewAdd(
+            MemberReviewRequest.Add request,
+            @CurrentUser User currentMember) {
         memberReviewService.addMemberReview(request, currentMember);
         ApiResult<Void> apiResult = ApiResult.<Void>success().build();
         return ResponseEntity.status(HttpStatus.CREATED).body(apiResult);

--- a/src/main/java/com/dnd/niceteam/review/controller/MemberReviewController.java
+++ b/src/main/java/com/dnd/niceteam/review/controller/MemberReviewController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,9 +24,18 @@ public class MemberReviewController {
 
     @PostMapping
     public ResponseEntity<ApiResult<Void>> memberReviewAdd(
-            MemberReviewRequest.Add request,
-            @CurrentUser User currentMember) {
-        memberReviewService.addMemberReview(request, currentMember);
+            @RequestBody MemberReviewRequest.Add request,
+            @CurrentUser User currentUser) {
+        memberReviewService.addMemberReview(request, currentUser);
+        ApiResult<Void> apiResult = ApiResult.<Void>success().build();
+        return ResponseEntity.status(HttpStatus.CREATED).body(apiResult);
+    }
+
+    @PostMapping("/skip")
+    public ResponseEntity<ApiResult<Void>> memberReviewSkip(
+            @RequestBody MemberReviewRequest.Skip request,
+            @CurrentUser User currentUser) {
+        memberReviewService.skipMemberReview(request, currentUser);
         ApiResult<Void> apiResult = ApiResult.<Void>success().build();
         return ResponseEntity.status(HttpStatus.CREATED).body(apiResult);
     }

--- a/src/main/java/com/dnd/niceteam/review/dto/MemberReviewRequest.java
+++ b/src/main/java/com/dnd/niceteam/review/dto/MemberReviewRequest.java
@@ -24,7 +24,7 @@ public interface MemberReviewRequest {
         @Positive
         @Max(5)
         @NotNull
-        private Integer hopeToReunionScore;
+        private Integer teamAgainScore;
 
         @NotNull
         private List<String> tagNames;
@@ -37,7 +37,7 @@ public interface MemberReviewRequest {
         public MemberReview toEntity(ProjectMember reviewer, ProjectMember reviewee, Set<MemberReviewTag> memberReviewTags) {
             return MemberReview.builder()
                     .participationScore(participationScore)
-                    .hopeToReunionScore(hopeToReunionScore)
+                    .teamAgainScore(teamAgainScore)
                     .reviewer(reviewer)
                     .reviewee(reviewee)
                     .memberReviewTags(memberReviewTags)

--- a/src/main/java/com/dnd/niceteam/review/dto/MemberReviewRequest.java
+++ b/src/main/java/com/dnd/niceteam/review/dto/MemberReviewRequest.java
@@ -13,8 +13,12 @@ import java.util.Set;
 
 public interface MemberReviewRequest {
 
+    Long getProjectId();
+
+    Long getRevieweeId();
+
     @Data
-    class Add {
+    class Add implements MemberReviewRequest {
 
         @Positive
         @Max(5)
@@ -43,6 +47,17 @@ public interface MemberReviewRequest {
                     .memberReviewTags(memberReviewTags)
                     .build();
         }
+
+    }
+
+    @Data
+    class Skip implements MemberReviewRequest {
+
+        @NotNull
+        private Long projectId;
+
+        @NotNull
+        private Long revieweeId;
 
     }
 }

--- a/src/main/java/com/dnd/niceteam/review/service/MemberReviewService.java
+++ b/src/main/java/com/dnd/niceteam/review/service/MemberReviewService.java
@@ -1,6 +1,7 @@
 package com.dnd.niceteam.review.service;
 
 import com.dnd.niceteam.domain.member.Member;
+import com.dnd.niceteam.domain.member.MemberRepositoryCustom;
 import com.dnd.niceteam.domain.project.LectureProjectRepository;
 import com.dnd.niceteam.domain.project.Project;
 import com.dnd.niceteam.domain.project.ProjectMember;
@@ -8,10 +9,12 @@ import com.dnd.niceteam.domain.project.ProjectMemberRepository;
 import com.dnd.niceteam.domain.review.MemberReview;
 import com.dnd.niceteam.domain.review.MemberReviewRepository;
 import com.dnd.niceteam.domain.review.MemberReviewTag;
+import com.dnd.niceteam.member.util.MemberUtils;
 import com.dnd.niceteam.project.exception.ProjectMemberNotFoundException;
 import com.dnd.niceteam.project.exception.ProjectNotFoundException;
 import com.dnd.niceteam.review.dto.MemberReviewRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,11 +29,14 @@ import java.util.stream.Collectors;
 public class MemberReviewService {
 
     private final MemberReviewRepository memberReviewRepository;
+    private final MemberRepositoryCustom memberRepositoryCustom;
     private final LectureProjectRepository lectureProjectRepository;
     private final ProjectMemberRepository projectMemberRepository;
 
     @Transactional
-    public MemberReview addMemberReview(MemberReviewRequest.Add request, Member currentMember) {
+    public MemberReview addMemberReview(MemberReviewRequest.Add request, User currentUser) {
+        Member currentMember = MemberUtils.findMemberByEmail(currentUser.getUsername(), memberRepositoryCustom);
+
         Project project = findProject(request.getProjectId());
         List<ProjectMember> projectMembers = projectMemberRepository.findByProject(project);
 

--- a/src/main/java/com/dnd/niceteam/security/CurrentUser.java
+++ b/src/main/java/com/dnd/niceteam/security/CurrentUser.java
@@ -8,5 +8,5 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @AuthenticationPrincipal
-public @interface CurrentMember {
+public @interface CurrentUser {
 }

--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -26,6 +26,11 @@ spring:
         format_sql: true
         use_sql_comments: true
         default_batch_fetch_size: 100
+    defer-datasource-initialization: true
+
+  sql:
+    init:
+      mode: always
 
 ---
 spring:

--- a/src/test/java/com/dnd/niceteam/domain/project/ProjectMemberRepositoryTest.java
+++ b/src/test/java/com/dnd/niceteam/domain/project/ProjectMemberRepositoryTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ProjectMemberRepositoryTest {
 
     @Autowired
-    private LectureProjectRepository lectureProjectRepository;
+    private ProjectRepository projectRepository;
 
     @Autowired
     private ProjectMemberRepository projectMemberRepository;
@@ -91,7 +91,7 @@ class ProjectMemberRepositoryTest {
                 .introduction("")
                 .introductionUrl("")
                 .build());
-        LectureProject doneProject = lectureProjectRepository.save(LectureProject.builder()
+        LectureProject doneProject = (LectureProject) projectRepository.save(LectureProject.builder()
                 .name("테스트 프로젝트 1")
                 .startDate(LocalDate.of(2022, 3, 2))
                 .endDate(LocalDate.of(2022, 6, 30))
@@ -107,7 +107,7 @@ class ProjectMemberRepositoryTest {
                 .project(doneProject)
                 .member(member)
                 .build());
-        LectureProject notStartedProject = lectureProjectRepository.save(LectureProject.builder()
+        LectureProject notStartedProject = (LectureProject) projectRepository.save(LectureProject.builder()
                 .name("테스트 프로젝트 2")
                 .startDate(LocalDate.of(2022, 3, 2))
                 .endDate(LocalDate.of(2022, 6, 30))

--- a/src/test/java/com/dnd/niceteam/project/service/LectureProjectServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/project/service/LectureProjectServiceTest.java
@@ -3,7 +3,7 @@ package com.dnd.niceteam.project.service;
 import com.dnd.niceteam.domain.department.Department;
 import com.dnd.niceteam.domain.department.DepartmentRepository;
 import com.dnd.niceteam.domain.project.LectureProject;
-import com.dnd.niceteam.domain.project.LectureProjectRepository;
+import com.dnd.niceteam.domain.project.ProjectRepository;
 import com.dnd.niceteam.error.exception.ErrorCode;
 import com.dnd.niceteam.project.LectureProjectTestFactory;
 import com.dnd.niceteam.project.dto.LectureProjectRequest;
@@ -32,7 +32,7 @@ class LectureProjectServiceTest {
     LectureProjectService lectureProjectService;
 
     @Mock
-    LectureProjectRepository lectureProjectRepository;
+    ProjectRepository projectRepository;
     @Mock
     DepartmentRepository departmentRepository;
 
@@ -47,7 +47,7 @@ class LectureProjectServiceTest {
         when(departmentRepository.findById(anyLong())).thenReturn(Optional.of(department));
 
         // when
-        when(lectureProjectRepository.save(any(LectureProject.class))).thenReturn(newLectureProject);
+        when(projectRepository.save(any(LectureProject.class))).thenReturn(newLectureProject);
         LectureProjectResponse.Detail response = lectureProjectService.registerLectureProject(request);
 
         // then

--- a/src/test/java/com/dnd/niceteam/review/MemberReviewTestFactory.java
+++ b/src/test/java/com/dnd/niceteam/review/MemberReviewTestFactory.java
@@ -13,7 +13,7 @@ public class MemberReviewTestFactory {
         List<String> tagNames = new ArrayList<>(List.of(MemberReviewTagName.책임감_굿.getKor(), MemberReviewTagName.마감을_칼같이.getKor()));
 
         request.setParticipationScore(5);
-        request.setHopeToReunionScore(4);
+        request.setTeamAgainScore(4);
         request.setProjectId(1L);
         request.setRevieweeId(revieweeId);
         request.setTagNames(tagNames);

--- a/src/test/java/com/dnd/niceteam/review/MemberReviewTestFactory.java
+++ b/src/test/java/com/dnd/niceteam/review/MemberReviewTestFactory.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class MemberReviewTestFactory {
 
-    public static MemberReviewRequest.Add getMemberReviewRequest(Long revieweeId) {
+    public static MemberReviewRequest.Add getAddRequest(Long revieweeId) {
         MemberReviewRequest.Add request = new MemberReviewRequest.Add();
         List<String> tagNames = new ArrayList<>(List.of(MemberReviewTagName.책임감_굿.getKor(), MemberReviewTagName.마감을_칼같이.getKor()));
 
@@ -21,8 +21,22 @@ public class MemberReviewTestFactory {
         return request;
     }
 
-    public static MemberReviewRequest.Add getMemberReviewRequest() {
-        return getMemberReviewRequest(2L);
+    public static MemberReviewRequest.Add getAddRequest() {
+        return getAddRequest(2L);
     }
+
+    public static MemberReviewRequest.Skip getSkipRequest(Long revieweeId) {
+        MemberReviewRequest.Skip request = new MemberReviewRequest.Skip();
+
+        request.setProjectId(1L);
+        request.setRevieweeId(revieweeId);
+
+        return request;
+    }
+
+    public static MemberReviewRequest.Skip getSkipRequest() {
+        return getSkipRequest(2L);
+    }
+
 
 }

--- a/src/test/java/com/dnd/niceteam/review/controller/MemberReviewControllerTest.java
+++ b/src/test/java/com/dnd/niceteam/review/controller/MemberReviewControllerTest.java
@@ -51,7 +51,7 @@ class MemberReviewControllerTest {
     @DisplayName("팀원 후기 등록")
     void addMemberReview() throws Exception {
         // given
-        MemberReviewRequest.Add request = MemberReviewTestFactory.getMemberReviewRequest();
+        MemberReviewRequest.Add request = MemberReviewTestFactory.getAddRequest();
 
         // then
         mockMvc.perform(
@@ -67,11 +67,38 @@ class MemberReviewControllerTest {
                         document("add-member-review",
                             requestFields(
                                     fieldWithPath("participationScore").description("참여도 점수"),
-                                    fieldWithPath("hopeToReunionScore").description("재팀원 희망 점수"),
+                                    fieldWithPath("teamAgainScore").description("재팀원 희망 점수"),
                                     fieldWithPath("tagNames").description("후기 태그 목록"),
                                     fieldWithPath("projectId").description("프로젝트 식별자"),
                                     fieldWithPath("revieweeId").description("피평가자 아이디")
                             )
+                        )
+                );
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("팀원 후기 건너뛰기")
+    void skipMemberReview() throws Exception {
+        // given
+        MemberReviewRequest.Skip request = MemberReviewTestFactory.getSkipRequest();
+
+        // then
+        mockMvc.perform(
+                        post("/member-reviews/skip")
+                                .with(csrf())
+                                .accept(MediaType.APPLICATION_JSON)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                ).andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andDo(
+                        document("skip-member-review",
+                                requestFields(
+                                        fieldWithPath("projectId").description("프로젝트 식별자"),
+                                        fieldWithPath("revieweeId").description("피평가자 아이디")
+                                )
                         )
                 );
     }

--- a/src/test/java/com/dnd/niceteam/review/service/MemberReviewServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/review/service/MemberReviewServiceTest.java
@@ -1,7 +1,11 @@
 package com.dnd.niceteam.review.service;
 
 import com.dnd.niceteam.domain.member.Member;
-import com.dnd.niceteam.domain.project.*;
+import com.dnd.niceteam.domain.member.MemberRepositoryCustom;
+import com.dnd.niceteam.domain.project.LectureProject;
+import com.dnd.niceteam.domain.project.LectureProjectRepository;
+import com.dnd.niceteam.domain.project.ProjectMember;
+import com.dnd.niceteam.domain.project.ProjectMemberRepository;
 import com.dnd.niceteam.domain.review.MemberReview;
 import com.dnd.niceteam.domain.review.MemberReviewRepository;
 import com.dnd.niceteam.review.MemberReviewTestFactory;
@@ -12,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.User;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +35,8 @@ class MemberReviewServiceTest {
     @Mock
     MemberReviewRepository memberReviewRepository;
     @Mock
+    MemberRepositoryCustom memberRepositoryCustom;
+    @Mock
     LectureProjectRepository lectureProjectRepository;
     @Mock
     ProjectMemberRepository projectMemberRepository;
@@ -40,10 +47,15 @@ class MemberReviewServiceTest {
         // given
         Long currentMemberId = 1L;
         Long revieweeId = 2L;
+        String email = "tester@gmail.com";
         MemberReviewRequest.Add request = MemberReviewTestFactory.getMemberReviewRequest(revieweeId);
+
+        User currentUser = mock(User.class);
+        when(currentUser.getUsername()).thenReturn(email);
 
         Member currentMember = mock(Member.class);
         when(currentMember.getId()).thenReturn(currentMemberId);
+        when(memberRepositoryCustom.findByEmail(anyString())).thenReturn(Optional.of(currentMember));
 
         LectureProject lectureProject = mock(LectureProject.class);
         when(lectureProjectRepository.findById(anyLong())).thenReturn(Optional.of(lectureProject));
@@ -58,7 +70,7 @@ class MemberReviewServiceTest {
         when(projectMemberRepository.findByProject(lectureProject)).thenReturn(projectMembers);
 
         // when
-        memberReviewService.addMemberReview(request, currentMember);
+        memberReviewService.addMemberReview(request, currentUser);
 
         // then
         verify(memberReviewRepository).save(any(MemberReview.class));


### PR DESCRIPTION
# 구현 내용/방법

- Controller에서 Spring Security의 UserDetails를 가져오기 위해 @CurrentUser 어노테이션을 사용했어요 :P
- 재팀원 희망 점수를 hopeToReunionScore 에서 → teamAgainScore로 변경했어요!

- ddl-auto: create-drop 방식에서 통합 테스트를 쉽게 진행할 수 있도록 data.sql을 통한 데이터 초기화 설정을 추가했어요!

- 팀원 리뷰 건너뛰기 기능을 추가하기 위해 Project 및 MemberReview의 Entity 세부사항을 수정했어요

    **Project** : @OneToMany projectMembers에 N+1 문제를 피하기 위한 @BatchSize 어노테이션 추가
    **MemberReview"
    1) skip 시 두 개의 점수 컬럼이 null이 돼야해서 nullable = true 로 바꿨어요
    2) 점수 컬럼들에 붙은 TINYINT unsigned를 제거했어요
    3) skipped의 기본 값을 false로 수정했어요
    4) 생성자에 reviwer, reviewee null 체크를 추가했어요
    

# 리뷰 필요

- Project Entity에 팀원 BatchSize를 임의로 100으로 설정했는데 별 문제 없을까요?
- MemberReviewService에 Tuple 데이터 구조를 대신하기 위해 내부 클래스인 ReviewerAndReviewee를 만들어 사용했는데 더 좋은 방법은 없는지 훌륭한 우리 7기 2조 팀원들의 인사이트를 구해요 🙇‍♂️

close #55
