### PR TITLE
fix(MemberReview): 팀원 후기 태그 Cascade.Persist 버그 수정

### DIFF
--- a/src/main/java/com/dnd/niceteam/domain/review/MemberReview.java
+++ b/src/main/java/com/dnd/niceteam/domain/review/MemberReview.java
@@ -1,5 +1,6 @@
 package com.dnd.niceteam.domain.review;
 
+import com.dnd.niceteam.domain.code.ReviewTag;
 import com.dnd.niceteam.domain.common.BaseEntity;
 import com.dnd.niceteam.domain.project.ProjectMember;
 import io.jsonwebtoken.lang.Assert;
@@ -13,6 +14,7 @@ import org.hibernate.annotations.Where;
 import javax.persistence.*;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -44,7 +46,7 @@ public class MemberReview extends BaseEntity {
     @JoinColumn(name = "reviewee_id", nullable = false)
     private ProjectMember reviewee;
 
-    @OneToMany(mappedBy = "memberReview", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "memberReview", cascade = { CascadeType.PERSIST, CascadeType.REMOVE })
     private Set<MemberReviewTag> memberReviewTags = new HashSet<>();
 
     @Builder
@@ -53,12 +55,18 @@ public class MemberReview extends BaseEntity {
             Integer teamAgainScore,
             ProjectMember reviewer,
             ProjectMember reviewee,
-            Set<MemberReviewTag> memberReviewTags
+            Set<ReviewTag> reviewTags
     ) {
 
         Assert.notNull(reviewer, "reviewer는 필수 값입니다.");
         Assert.notNull(reviewee, "reviewee는 필수 값입니다.");
 
+        Set<MemberReviewTag> memberReviewTags = null;
+
+        if (reviewTags != null) {
+            memberReviewTags = reviewTags.stream().map(tag ->
+                    new MemberReviewTag(tag, this)).collect(Collectors.toSet());
+        }
 
         this.participationScore = participationScore;
         this.teamAgainScore = teamAgainScore;

--- a/src/main/java/com/dnd/niceteam/domain/review/MemberReviewTag.java
+++ b/src/main/java/com/dnd/niceteam/domain/review/MemberReviewTag.java
@@ -1,5 +1,6 @@
 package com.dnd.niceteam.domain.review;
 
+import com.dnd.niceteam.domain.code.ReviewTag;
 import com.dnd.niceteam.domain.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -27,18 +28,15 @@ public class MemberReviewTag extends BaseEntity {
 
     @Column(name = "tag", nullable = false)
     @Enumerated(EnumType.STRING)
-    private MemberReviewTagName tag;
+    private ReviewTag tag;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_review_id", nullable = false)
     private MemberReview memberReview;
 
-    public MemberReviewTag(String tagName) {
-        this.tag = MemberReviewTagName.getByKor(tagName);
-    }
-
-    public MemberReviewTag(MemberReviewTagName tag) {
+    public MemberReviewTag(ReviewTag tag, MemberReview memberReview) {
         this.tag = tag;
+        this.memberReview = memberReview;
     }
 
     @Override

--- a/src/main/java/com/dnd/niceteam/review/dto/MemberReviewRequest.java
+++ b/src/main/java/com/dnd/niceteam/review/dto/MemberReviewRequest.java
@@ -1,14 +1,13 @@
 package com.dnd.niceteam.review.dto;
 
+import com.dnd.niceteam.domain.code.ReviewTag;
 import com.dnd.niceteam.domain.project.ProjectMember;
 import com.dnd.niceteam.domain.review.MemberReview;
-import com.dnd.niceteam.domain.review.MemberReviewTag;
 import lombok.Data;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
-import java.util.List;
 import java.util.Set;
 
 public interface MemberReviewRequest {
@@ -31,22 +30,23 @@ public interface MemberReviewRequest {
         private Integer teamAgainScore;
 
         @NotNull
-        private List<String> tagNames;
+        private Set<ReviewTag> reviewTags;
 
         @NotNull
         private Long projectId;
         @NotNull
         private Long revieweeId;
 
-        public MemberReview toEntity(ProjectMember reviewer, ProjectMember reviewee, Set<MemberReviewTag> memberReviewTags) {
+        public MemberReview toEntity(ProjectMember reviewer, ProjectMember reviewee) {
             return MemberReview.builder()
                     .participationScore(participationScore)
                     .teamAgainScore(teamAgainScore)
                     .reviewer(reviewer)
                     .reviewee(reviewee)
-                    .memberReviewTags(memberReviewTags)
+                    .reviewTags(reviewTags)
                     .build();
         }
+
 
     }
 

--- a/src/main/java/com/dnd/niceteam/review/service/MemberReviewService.java
+++ b/src/main/java/com/dnd/niceteam/review/service/MemberReviewService.java
@@ -7,7 +7,6 @@ import com.dnd.niceteam.domain.project.ProjectMember;
 import com.dnd.niceteam.domain.project.ProjectRepository;
 import com.dnd.niceteam.domain.review.MemberReview;
 import com.dnd.niceteam.domain.review.MemberReviewRepository;
-import com.dnd.niceteam.domain.review.MemberReviewTag;
 import com.dnd.niceteam.member.util.MemberUtils;
 import com.dnd.niceteam.project.exception.ProjectMemberNotFoundException;
 import com.dnd.niceteam.project.exception.ProjectNotFoundException;
@@ -17,10 +16,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,12 +31,9 @@ public class MemberReviewService {
     public void addMemberReview(MemberReviewRequest.Add request, User currentUser) {
         ReviewerAndReviewee projectMember = getReviewerAndReviewee(request, currentUser);
 
-        Set<MemberReviewTag> tags = getMemberReviewTags(request.getTagNames());
-
         MemberReview newMemberReview = request.toEntity(
                 projectMember.reviewer,
-                projectMember.reviewee,
-                tags
+                projectMember.reviewee
         );
         memberReviewRepository.save(newMemberReview);
     }
@@ -71,10 +64,6 @@ public class MemberReviewService {
         ProjectMember reviewee = findProjectMemberFrom(project, revieweeId);
 
         return new ReviewerAndReviewee(reviewer, reviewee);
-    }
-
-    private Set<MemberReviewTag> getMemberReviewTags(List<String> tagNames) {
-        return tagNames.stream().map(MemberReviewTag::new).collect(Collectors.toSet());
     }
 
     /* DB 조회 메서드 */


### PR DESCRIPTION
# 구현 내용/방법

- 팀원 후기 태그에 Cascade.Persist 적용
- 영래님이 준비해주신 ReviewTag로 기존 MemberReviewTagName Enum 대체

close #70
