### PR TITLE
Feature/#73 프로젝트 수정 기능 추가

### DIFF
--- a/src/main/java/com/dnd/niceteam/domain/project/LectureProject.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/LectureProject.java
@@ -1,10 +1,7 @@
 package com.dnd.niceteam.domain.project;
 
 import com.dnd.niceteam.domain.department.Department;
-import io.jsonwebtoken.lang.Assert;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -16,6 +13,7 @@ import java.util.Set;
 @Table(name = "lecture_project")
 @NoArgsConstructor
 @DiscriminatorValue("LECTURE")
+@ToString(callSuper = true)
 public class LectureProject extends Project {
 
     @Column(length = 50, nullable = false)
@@ -37,17 +35,26 @@ public class LectureProject extends Project {
             String name,
             LocalDate startDate,
             LocalDate endDate,
-            String professor,
-            Department department,
-            Set<LectureTime> lectureTimes
+            @NonNull String professor,
+            @NonNull Department department,
+            @NonNull Set<LectureTime> lectureTimes
     ) {
         super(name, startDate, endDate);
-        Assert.hasText(professor, "professor은 필수 값입니다.");
-        Assert.notNull(department, "department는 필수 값입니다.");
-        Assert.notEmpty(lectureTimes, "lectureTimes는 필수 값입니다.");
 
         this.professor = professor;
         this.department = department;
         this.lectureTimes = lectureTimes;
+    }
+
+    public void setProfessor(String professor) {
+        if (professor != null) this.professor = professor;
+    }
+
+    public void setDepartment(Department department) {
+        if (department != null) this.department = department;
+    }
+
+    public void setLectureTimes(Set<LectureTime> lectureTimes) {
+        if (lectureTimes != null) this.lectureTimes = lectureTimes;
     }
 }

--- a/src/main/java/com/dnd/niceteam/domain/project/Project.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/Project.java
@@ -1,11 +1,9 @@
 package com.dnd.niceteam.domain.project;
 
+import com.dnd.niceteam.domain.code.Type;
 import com.dnd.niceteam.domain.common.BaseEntity;
 import com.dnd.niceteam.domain.member.Member;
-import io.jsonwebtoken.lang.Assert;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
@@ -23,6 +21,7 @@ import java.util.Set;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn(name = "type")
+@ToString
 public abstract class Project extends BaseEntity {
 
     @Id
@@ -32,6 +31,10 @@ public abstract class Project extends BaseEntity {
 
     @Column(name = "name", nullable = false)
     private String name;
+
+    @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Type type;
 
     @Column(name = "start_date", nullable = false)
     private LocalDate startDate;
@@ -47,11 +50,7 @@ public abstract class Project extends BaseEntity {
     @OneToMany(mappedBy = "project")
     private Set<ProjectMember> projectMembers = new HashSet<>();
 
-    protected Project(String name, LocalDate startDate, LocalDate endDate) {
-        Assert.hasText(name, "name은 필수 값입니다.");
-        Assert.notNull(startDate, "startDate는 필수 값입니다.");
-        Assert.notNull(endDate, "endDate는 필수 값입니다.");
-
+    protected Project(@NonNull String name, @NonNull LocalDate startDate, @NonNull LocalDate endDate) {
         this.name = name;
         this.startDate = startDate;
         this.endDate = endDate;
@@ -65,6 +64,18 @@ public abstract class Project extends BaseEntity {
         projectMembers.add(projectMember);
     }
 
+    public void setName(String name) {
+        if (name != null) this.name = name;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        if (startDate != null) this.startDate = startDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        if (endDate != null) this.endDate = endDate;
+    }
+
     public void start() {
         this.status = ProjectStatus.IN_PROGRESS;
     }
@@ -72,4 +83,5 @@ public abstract class Project extends BaseEntity {
     public void end() {
         this.status = ProjectStatus.DONE;
     }
+
 }

--- a/src/main/java/com/dnd/niceteam/domain/project/ProjectRepository.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/ProjectRepository.java
@@ -1,0 +1,7 @@
+package com.dnd.niceteam.domain.project;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+}

--- a/src/main/java/com/dnd/niceteam/domain/project/SideProject.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/SideProject.java
@@ -2,9 +2,7 @@ package com.dnd.niceteam.domain.project;
 
 import com.dnd.niceteam.domain.code.Field;
 import com.dnd.niceteam.domain.code.FieldCategory;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -14,6 +12,7 @@ import java.time.LocalDate;
 @Table(name = "side_project")
 @NoArgsConstructor
 @DiscriminatorValue("SIDE")
+@ToString(callSuper = true)
 public class SideProject extends Project {
 
     @Column(name = "field", length = 25, nullable = false)
@@ -29,12 +28,20 @@ public class SideProject extends Project {
             String name,
             LocalDate startDate,
             LocalDate endDate,
-            Field field,
-            FieldCategory fieldCategory
+            @NonNull Field field,
+            @NonNull FieldCategory fieldCategory
     ) {
         super(name, startDate, endDate);
         this.field = field;
         this.fieldCategory = fieldCategory;
+    }
+
+    public void setField(Field field) {
+        if (field != null) this.field = field;
+    }
+
+    public void setFieldCategory(FieldCategory fieldCategory) {
+        if (fieldCategory != null) this.fieldCategory = fieldCategory;
     }
 
 }

--- a/src/main/java/com/dnd/niceteam/project/dto/ProjectRequest.java
+++ b/src/main/java/com/dnd/niceteam/project/dto/ProjectRequest.java
@@ -66,8 +66,6 @@ public interface ProjectRequest {
     @Data
     class Update {
 
-        private Type type;
-
         private String name;
         private LocalDate startDate;
         private LocalDate endDate;

--- a/src/main/java/com/dnd/niceteam/review/service/MemberReviewService.java
+++ b/src/main/java/com/dnd/niceteam/review/service/MemberReviewService.java
@@ -4,7 +4,7 @@ import com.dnd.niceteam.domain.member.Member;
 import com.dnd.niceteam.domain.member.MemberRepository;
 import com.dnd.niceteam.domain.project.Project;
 import com.dnd.niceteam.domain.project.ProjectMember;
-import com.dnd.niceteam.domain.project.SideProjectRepository;
+import com.dnd.niceteam.domain.project.ProjectRepository;
 import com.dnd.niceteam.domain.review.MemberReview;
 import com.dnd.niceteam.domain.review.MemberReviewRepository;
 import com.dnd.niceteam.member.util.MemberUtils;
@@ -25,7 +25,7 @@ public class MemberReviewService {
 
     private final MemberReviewRepository memberReviewRepository;
     private final MemberRepository memberRepository;
-    private final SideProjectRepository sideProjectRepository;
+    private final ProjectRepository projectRepository;
 
     @Transactional
     public void addMemberReview(MemberReviewRequest.Add request, User currentUser) {
@@ -69,7 +69,7 @@ public class MemberReviewService {
     /* DB 조회 메서드 */
     // DB 조회 : Project
     private Project findProjectById(Long projectId) {
-        return sideProjectRepository.findById(projectId)
+        return projectRepository.findById(projectId)
                 .orElseThrow(() -> new ProjectNotFoundException("id = " + projectId));
     }
 

--- a/src/test/java/com/dnd/niceteam/project/ProjectTestFactory.java
+++ b/src/test/java/com/dnd/niceteam/project/ProjectTestFactory.java
@@ -21,9 +21,7 @@ public class ProjectTestFactory {
     private static final String PROFESSOR = "양경호 교수";
 
     public static ProjectRequest.Register createRegisterRequest(Type type) {
-        LectureTimeRequest lectureTimeRequest = new LectureTimeRequest();
-        lectureTimeRequest.setDayOfWeek(DayOfWeek.MON);
-        lectureTimeRequest.setStartTime(LocalTime.of(8, 0));
+        LectureTimeRequest lectureTimeRequest = createLectureTimeRequest(DayOfWeek.MON, LocalTime.of(8, 0));
 
         ProjectRequest.Register request = new ProjectRequest.Register();
 
@@ -40,6 +38,14 @@ public class ProjectTestFactory {
             request.setField(Field.AD_MARKETING);
             request.setFieldCategory(FieldCategory.STUDY);
         }
+
+        return request;
+    }
+
+    public static LectureTimeRequest createLectureTimeRequest(DayOfWeek dayOfWeek, LocalTime startTime) {
+        LectureTimeRequest request = new LectureTimeRequest();
+        request.setDayOfWeek(dayOfWeek);
+        request.setStartTime(startTime);
 
         return request;
     }

--- a/src/test/java/com/dnd/niceteam/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/project/service/ProjectServiceTest.java
@@ -5,15 +5,14 @@ import com.dnd.niceteam.domain.department.Department;
 import com.dnd.niceteam.domain.department.DepartmentRepository;
 import com.dnd.niceteam.domain.project.LectureProject;
 import com.dnd.niceteam.domain.project.LectureProjectRepository;
-import com.dnd.niceteam.domain.project.SideProjectRepository;
 import com.dnd.niceteam.domain.project.SideProject;
+import com.dnd.niceteam.domain.project.SideProjectRepository;
 import com.dnd.niceteam.error.exception.ErrorCode;
 import com.dnd.niceteam.project.ProjectTestFactory;
 import com.dnd.niceteam.project.dto.DepartmentResponse;
 import com.dnd.niceteam.project.dto.ProjectRequest;
 import com.dnd.niceteam.project.dto.ProjectResponse;
 import com.dnd.niceteam.project.exception.InvalidProjectSchedule;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,16 +37,11 @@ class ProjectServiceTest {
     ProjectService projectService;
 
     @Mock
-    LectureProjectRepository lectureSideProjectRepository;
+    LectureProjectRepository lectureProjectRepository;
     @Mock
     SideProjectRepository sideProjectRepository;
     @Mock
     DepartmentRepository departmentRepository;
-
-    @BeforeEach
-    void setUp() {
-
-    }
 
     @DisplayName("신규 강의 프로젝트 등록")
     @Test
@@ -59,7 +53,7 @@ class ProjectServiceTest {
         when(departmentRepository.findById(anyLong())).thenReturn(Optional.of(department));
 
         LectureProject newLectureProject = request.toLectureProject(department);
-        when(lectureSideProjectRepository.save(any(LectureProject.class))).thenReturn(newLectureProject);
+        when(lectureProjectRepository.save(any(LectureProject.class))).thenReturn(newLectureProject);
 
         try (MockedStatic<DepartmentResponse> mockedDepartmentResponse = mockStatic(DepartmentResponse.class, RETURNS_DEEP_STUBS)) {
             DepartmentResponse departmentResponse = mock(DepartmentResponse.class, RETURNS_DEEP_STUBS);

--- a/src/test/java/com/dnd/niceteam/review/service/MemberReviewServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/review/service/MemberReviewServiceTest.java
@@ -2,10 +2,7 @@ package com.dnd.niceteam.review.service;
 
 import com.dnd.niceteam.domain.member.Member;
 import com.dnd.niceteam.domain.member.MemberRepository;
-import com.dnd.niceteam.domain.project.Project;
-import com.dnd.niceteam.domain.project.ProjectMember;
-import com.dnd.niceteam.domain.project.SideProjectRepository;
-import com.dnd.niceteam.domain.project.SideProject;
+import com.dnd.niceteam.domain.project.*;
 import com.dnd.niceteam.domain.review.MemberReview;
 import com.dnd.niceteam.domain.review.MemberReviewRepository;
 import com.dnd.niceteam.review.MemberReviewTestFactory;
@@ -39,7 +36,7 @@ class MemberReviewServiceTest {
     @Mock
     MemberRepository memberRepository;
     @Mock
-    SideProjectRepository sideProjectRepository;
+    ProjectRepository projectRepository;
 
     static final long reviwerId = 1L;
     static final long revieweeId = 2L;
@@ -80,7 +77,7 @@ class MemberReviewServiceTest {
         when(memberRepository.findById(revieweeId)).thenReturn(Optional.of(revieweeMember));
 
         SideProject project = mock(SideProject.class);
-        when(sideProjectRepository.findById(anyLong())).thenReturn(Optional.of(project));
+        when(projectRepository.findById(anyLong())).thenReturn(Optional.of(project));
 
         Set<ProjectMember> projectMembers = new HashSet<>(List.of(reviewer, reviewee));
         when(project.getProjectMembers()).thenReturn(projectMembers);
@@ -103,7 +100,7 @@ class MemberReviewServiceTest {
             when(memberRepository.findById(anyLong())).thenReturn(Optional.of(revieweeMember));
 
             SideProject sideProject = mock(SideProject.class);
-            when(sideProjectRepository.findById(request.getProjectId())).thenReturn(Optional.of(sideProject));
+            when(projectRepository.findById(request.getProjectId())).thenReturn(Optional.of(sideProject));
 
             Set<ProjectMember> projectMembers = new HashSet<>(List.of(reviewer, reviewee));
             when(sideProject.getProjectMembers()).thenReturn(projectMembers);


### PR DESCRIPTION
# 구현 내용/방법

- ProjectService에 윤지님이 사용하실 프로젝트 수정 메서드를 추가했어요

    → 강의/사이드 팀플 둘 다 하나의 메서드로 받아 처리해 엔드 포인트를 단순화시켰어요
    
- 프로젝트 수정을 위해 Setter 메서드들을 추가했어요
- Project 관련 Entity Null 체크 방식을 Assert 대신 롬복 @NonNull로 변경했어요

# 리뷰 필요

- JpaRepository를 확장한 ProjectRepository를 Generic으로 받아서 써보려고 했는데

    1) @Inheritance(strategy = InheritanceType.JOINED) 적용 시 테스트쪽에서 문제가 생겨서
    2) 윤지님께 빨리 사용 가능한 인터페이스를 제공해드리고자 우선 3개의 Repository를 연결해놓았고
    3) 이후에  QueryDSL 등을 이용해 하나로 리팩토링 진행하려고 7~8주차 태스크에 등록해뒀어요
    
    혹시 이 부분에 대해서 좋은 인사이트가 있다면 알려주세요 🙇‍♂️

close #73
