### PR TITLE
Refactor/#65 모집글의 댓글 갯수 증가 로직

### DIFF
--- a/src/main/java/com/dnd/niceteam/comment/controller/CommentController.java
+++ b/src/main/java/com/dnd/niceteam/comment/controller/CommentController.java
@@ -18,10 +18,11 @@ public class CommentController {
 
     @PostMapping
     public ResponseEntity<ApiResult<CommentCreation.ResponseDto>> commentAdd(@PathVariable Long recruitingId,
-                                                                             @RequestBody @Valid CommentCreation.RequestDto commentDto) {
-        CommentCreation.ResponseDto responseDto = commentService.addComment(recruitingId, commentDto);
+                                                                             @RequestBody @Valid CommentCreation.RequestDto requestDto) {
+        CommentCreation.ResponseDto responseDto = commentService.addComment(recruitingId, requestDto);
 
         ApiResult<CommentCreation.ResponseDto> apiResult = ApiResult.success(responseDto);
         return new ResponseEntity<>(apiResult, HttpStatus.CREATED);
     }
+
 }

--- a/src/main/java/com/dnd/niceteam/comment/controller/CommentController.java
+++ b/src/main/java/com/dnd/niceteam/comment/controller/CommentController.java
@@ -6,6 +6,7 @@ import com.dnd.niceteam.common.dto.ApiResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -19,7 +20,8 @@ public class CommentController {
     @PostMapping
     public ResponseEntity<ApiResult<CommentCreation.ResponseDto>> commentAdd(@PathVariable Long recruitingId,
                                                                              @RequestBody @Valid CommentCreation.RequestDto requestDto) {
-        CommentCreation.ResponseDto responseDto = commentService.addComment(recruitingId, requestDto);
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        CommentCreation.ResponseDto responseDto = commentService.addComment(recruitingId, username, requestDto);
 
         ApiResult<CommentCreation.ResponseDto> apiResult = ApiResult.success(responseDto);
         return new ResponseEntity<>(apiResult, HttpStatus.CREATED);

--- a/src/main/java/com/dnd/niceteam/comment/dto/CommentCreation.java
+++ b/src/main/java/com/dnd/niceteam/comment/dto/CommentCreation.java
@@ -12,8 +12,6 @@ import javax.validation.constraints.Size;
 public interface CommentCreation {
     @Data
     class RequestDto {
-        @NotNull
-        private Long memberId;
         @Size(max = 255)
         @NotNull
         private String content;

--- a/src/main/java/com/dnd/niceteam/comment/service/CommentService.java
+++ b/src/main/java/com/dnd/niceteam/comment/service/CommentService.java
@@ -1,7 +1,7 @@
 package com.dnd.niceteam.comment.service;
 
 import com.dnd.niceteam.comment.dto.CommentCreation;
-import com.dnd.niceteam.comment.exception.RecruitingNotFoundException;
+import com.dnd.niceteam.recruiting.exception.RecruitingNotFoundException;
 import com.dnd.niceteam.domain.comment.Comment;
 import com.dnd.niceteam.domain.comment.CommentRepository;
 import com.dnd.niceteam.domain.member.Member;
@@ -23,13 +23,21 @@ public class CommentService {
 
     @Transactional
     public CommentCreation.ResponseDto addComment(Long recruitingId, CommentCreation.RequestDto commentDto) {
-        Comment savedComment = commentRepository.save(commentDto.toEntity(getMemberEntity(recruitingId),
-                getRecruitingtEntity(recruitingId)));
+        Recruiting recruiting = getRecruitingtEntity(recruitingId);
+        recruiting.plusCommentCount();
+
+        Comment savedComment = commentRepository.save(
+                commentDto.toEntity(
+                        getMemberEntity(recruitingId),
+                        recruiting
+                )
+        );
 
         CommentCreation.ResponseDto response = new CommentCreation.ResponseDto();
         response.setId(savedComment.getId());
         return response;
     }
+
 
     private Recruiting getRecruitingtEntity(Long recruitingId) {
         return recruitingRepository.findById(recruitingId)

--- a/src/main/java/com/dnd/niceteam/comment/service/CommentService.java
+++ b/src/main/java/com/dnd/niceteam/comment/service/CommentService.java
@@ -1,14 +1,14 @@
 package com.dnd.niceteam.comment.service;
 
 import com.dnd.niceteam.comment.dto.CommentCreation;
-import com.dnd.niceteam.recruiting.exception.RecruitingNotFoundException;
-import com.dnd.niceteam.domain.comment.Comment;
-import com.dnd.niceteam.domain.comment.CommentRepository;
 import com.dnd.niceteam.domain.member.Member;
 import com.dnd.niceteam.domain.member.MemberRepository;
-import com.dnd.niceteam.domain.member.exception.MemberNotFoundException;
+import com.dnd.niceteam.domain.recruiting.exception.RecruitingNotFoundException;
+import com.dnd.niceteam.domain.comment.Comment;
+import com.dnd.niceteam.domain.comment.CommentRepository;
 import com.dnd.niceteam.domain.recruiting.Recruiting;
 import com.dnd.niceteam.domain.recruiting.RecruitingRepository;
+import com.dnd.niceteam.member.util.MemberUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,15 +22,13 @@ public class CommentService {
     private final RecruitingRepository recruitingRepository;
 
     @Transactional
-    public CommentCreation.ResponseDto addComment(Long recruitingId, CommentCreation.RequestDto commentDto) {
+    public CommentCreation.ResponseDto addComment(Long recruitingId, String username, CommentCreation.RequestDto commentDto) {
         Recruiting recruiting = getRecruitingtEntity(recruitingId);
         recruiting.plusCommentCount();
 
+        Member member = MemberUtils.findMemberByEmail(username, memberRepository);
         Comment savedComment = commentRepository.save(
-                commentDto.toEntity(
-                        getMemberEntity(recruitingId),
-                        recruiting
-                )
+                commentDto.toEntity(member, recruiting)
         );
 
         CommentCreation.ResponseDto response = new CommentCreation.ResponseDto();
@@ -38,14 +36,9 @@ public class CommentService {
         return response;
     }
 
-
     private Recruiting getRecruitingtEntity(Long recruitingId) {
         return recruitingRepository.findById(recruitingId)
                 .orElseThrow(() -> new RecruitingNotFoundException("recruitingId = " + recruitingId));
     }
 
-    private Member getMemberEntity(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException("memberId = " + memberId));
-    }
 }

--- a/src/main/java/com/dnd/niceteam/common/Domain.java
+++ b/src/main/java/com/dnd/niceteam/common/Domain.java
@@ -13,6 +13,8 @@ public enum Domain {
     PROJECT,
     PROJECT_MEMBER,
 
-    RECRUITING
-    ;
+    RECRUITING,
+    COMMENT,
+    APPLICANT
+
 }

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/Recruiting.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/Recruiting.java
@@ -6,10 +6,8 @@ import com.dnd.niceteam.domain.code.ProgressStatus;
 import com.dnd.niceteam.domain.code.Type;
 import com.dnd.niceteam.domain.common.BaseEntity;
 import com.dnd.niceteam.domain.member.Member;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import com.dnd.niceteam.domain.project.Project;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -20,6 +18,7 @@ import java.util.Set;
 
 @Entity
 @Builder
+@Getter
 @SQLDelete(sql = "UPDATE recruiting SET use_yn = false WHERE recruiting_id = ?")
 @Where(clause = "use_yn = true")
 @AllArgsConstructor
@@ -32,9 +31,9 @@ public class Recruiting extends BaseEntity {
     @Column(name = "recruiting_id")
     private Long id;
 
-//    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-//    @JoinColumn(name = "project_id", nullable = false)
-//    private Project project;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_id", nullable = false)
@@ -73,8 +72,12 @@ public class Recruiting extends BaseEntity {
     @Column(name = "intro_link")
     private String introLink;
 
+    @Builder.Default
     @ElementCollection
     @CollectionTable(name="recruiting_personality", joinColumns = @JoinColumn(name= "recruiting_id", nullable = false))
     private Set<Personality> personalities = new HashSet<>();
 
+    public void plusCommentCount() {
+        this.commentCount += 1;
+    }
 }

--- a/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
@@ -42,9 +42,12 @@ public enum ErrorCode {
     // Recruiting
     INVALID_RECRUITING_TYPE(RECRUITING, SC_BAD_REQUEST, "모집글 타입이 유효하지 않습니다."),
     RECRUITING_NOT_FOUND(RECRUITING, SC_NOT_FOUND, "존재하지 않는 모집글입니다."),
-    APPLY_IMPOSSIBLE_RECRUITING_STATUS(RECRUITING, SC_BAD_REQUEST, "지원 불가능한 모집글입니다."),
+    APPLY_IMPOSSIBLE_RECRUITING(RECRUITING, SC_BAD_REQUEST, "지원 불가능한 모집글입니다."),
+    APPLY_CANCEL_IMPOSSIBLE_RECRUITING(RECRUITING, SC_BAD_REQUEST, "지원 취소가 불가능한 모집글입니다."),
 
     COMMENT_NOT_FOUND(COMMENT, SC_NOT_FOUND, "존재하지 않는 댓글입니다."),
+
+    APPLY_ALREADY_ACCEPTED(APPLICANT, SC_BAD_REQUEST, "이미 수락된 지원입니다.")
     ;
 
     private final Domain domain;

--- a/src/test/java/com/dnd/niceteam/comment/CommentTestFactory.java
+++ b/src/test/java/com/dnd/niceteam/comment/CommentTestFactory.java
@@ -5,12 +5,10 @@ import com.dnd.niceteam.comment.dto.CommentCreation;
 public class CommentTestFactory {
     public static final String COMMENT_CONTENT = "모집글의 댓글입니다.";
     public static final Long PARENT_ID = 0L;
-    public static final Long MEMBER_ID = 1L;
     public static final Long RECRUITING_ID = 1L;
 
     public static CommentCreation.RequestDto createCommentRequest() {
         CommentCreation.RequestDto dto = new CommentCreation.RequestDto();
-        dto.setMemberId(MEMBER_ID);
         dto.setContent(COMMENT_CONTENT);
         dto.setParentId(PARENT_ID);
         return dto;

--- a/src/test/java/com/dnd/niceteam/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/dnd/niceteam/comment/controller/CommentControllerTest.java
@@ -2,7 +2,7 @@ package com.dnd.niceteam.comment.controller;
 
 import com.dnd.niceteam.comment.dto.CommentCreation;
 import com.dnd.niceteam.comment.service.CommentService;
-import com.dnd.niceteam.comment.service.CommentTestFactory;
+import com.dnd.niceteam.comment.CommentTestFactory;
 import com.dnd.niceteam.common.RestDocsConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static com.dnd.niceteam.comment.service.CommentTestFactory.RECRUITING_ID;
+import static com.dnd.niceteam.comment.CommentTestFactory.RECRUITING_ID;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -50,22 +50,22 @@ class CommentControllerTest {
 
         //then
         mockMvc.perform(
-                        post("/recruiting/{recruitingId}/comment", RECRUITING_ID)
-                                .with(csrf())
-                                .accept(MediaType.APPLICATION_JSON)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(request))
+                post("/recruiting/{recruitingId}/comment", RECRUITING_ID)
+                        .with(csrf())
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
                 ).andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value(true))
                 .andDo(
                         document("comment-create",
                                 requestFields(
-                                        fieldWithPath("memberId").description("회원 ID"),
+                                        fieldWithPath("memberId").description("회원 식별자 ID"),
                                         fieldWithPath("content").description("댓글 내용")
                                                 .attributes(key("constraint").value("최대 255자")),
                                         fieldWithPath("parentId").description("모댓글 ID")
-                                                .attributes(key("constraint").value("모댓글인 경우 0으로 처리"))
+                                                .attributes(key("constraint").value("모댓글인 경우 0으로 요청"))
                                         ),
                                 responseFields(
                                         beneathPath("data").withSubsectionId("data"),

--- a/src/test/java/com/dnd/niceteam/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/dnd/niceteam/comment/controller/CommentControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static com.dnd.niceteam.comment.CommentTestFactory.RECRUITING_ID;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -46,7 +47,7 @@ class CommentControllerTest {
         //given
         CommentCreation.RequestDto request = CommentTestFactory.createCommentRequest();
         CommentCreation.ResponseDto response = CommentTestFactory.createCommentResponse();
-        when(commentService.addComment(RECRUITING_ID, request)).thenReturn(response);
+        when(commentService.addComment(anyLong(), anyString(), eq(request))).thenReturn(response);
 
         //then
         mockMvc.perform(
@@ -61,7 +62,6 @@ class CommentControllerTest {
                 .andDo(
                         document("comment-create",
                                 requestFields(
-                                        fieldWithPath("memberId").description("회원 식별자 ID"),
                                         fieldWithPath("content").description("댓글 내용")
                                                 .attributes(key("constraint").value("최대 255자")),
                                         fieldWithPath("parentId").description("모댓글 ID")

--- a/src/test/java/com/dnd/niceteam/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/comment/service/CommentServiceTest.java
@@ -1,53 +1,168 @@
 package com.dnd.niceteam.comment.service;
 
 import com.dnd.niceteam.comment.dto.CommentCreation;
+import com.dnd.niceteam.common.TestJpaConfig;
+import com.dnd.niceteam.domain.account.Account;
+import com.dnd.niceteam.domain.account.AccountRepository;
+import com.dnd.niceteam.domain.code.*;
 import com.dnd.niceteam.domain.comment.Comment;
 import com.dnd.niceteam.domain.comment.CommentRepository;
+import com.dnd.niceteam.domain.department.Department;
+import com.dnd.niceteam.domain.department.DepartmentRepository;
 import com.dnd.niceteam.domain.member.Member;
 import com.dnd.niceteam.domain.member.MemberRepository;
+import com.dnd.niceteam.domain.memberscore.MemberScore;
+import com.dnd.niceteam.domain.memberscore.MemberScoreRepository;
+import com.dnd.niceteam.domain.project.LectureProject;
+import com.dnd.niceteam.domain.project.LectureProjectRepository;
+import com.dnd.niceteam.domain.project.LectureTime;
 import com.dnd.niceteam.domain.recruiting.Recruiting;
 import com.dnd.niceteam.domain.recruiting.RecruitingRepository;
+import com.dnd.niceteam.domain.university.University;
+import com.dnd.niceteam.domain.university.UniversityRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
+import javax.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Set;
 
-import static com.dnd.niceteam.comment.service.CommentTestFactory.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.*;
 
-@ExtendWith(MockitoExtension.class)
+@DataJpaTest
+@Import({TestJpaConfig.class, CommentService.class})
+@Transactional
 class CommentServiceTest {
-    @InjectMocks CommentService commentService;
+    @Autowired
+    private MemberRepository memberRepository;
 
-    @Mock CommentRepository commentRepository;
-    @Mock MemberRepository memberRepository;
-    @Mock RecruitingRepository recruitingRepository;
+    @Autowired
+    private AccountRepository accountRepository;
 
+    @Autowired
+    private UniversityRepository universityRepository;
+
+    @Autowired
+    private DepartmentRepository departmentRepository;
+
+    @Autowired
+    private MemberScoreRepository memberScoreRepository;
+
+    @Autowired
+    private LectureProjectRepository projectRepository;
+
+    @Autowired
+    private RecruitingRepository recruitingRepository;
+
+    @Autowired
+    private CommentService commentService;
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    University university;
+    Department department;
+    MemberScore memberScore;
+    Account account;
+    Member member;
+    LectureProject project;
+    Recruiting recruiting;
+    // TODO: 2022-08-13 중복 제거 리팩토링 가능할지
+    @BeforeEach
+    void init() {
+        //given
+        university = universityRepository.save(University.builder()
+                .name("테스트대학교")
+                .emailDomain("email.com")
+                .build());
+        department = departmentRepository.save(Department.builder()
+                .university(university)
+                .collegeName("단과대학")
+                .name("학과")
+                .region("서울")
+                .mainBranchType("본교")
+                .build());
+        memberScore = memberScoreRepository.save(MemberScore.builder()
+                .level(1)
+                .reviewNum(0)
+                .totalParticipationScore(0)
+                .totalTeamAgainScore(0)
+                .build());
+        account = accountRepository.save(Account.builder()
+                .email("test@email.com")
+                .password("testPassword123!@#")
+                .build());
+        member = memberRepository.save(Member.builder()
+                .account(account)
+                .university(university)
+                .department(department)
+                .memberScore(memberScore)
+                .nickname("테스트닉네임")
+                .admissionYear(2017)
+                .personality(new Personality(Personality.Adjective.LOGICAL, Personality.Noun.LEADER))
+                .introduction("")
+                .introductionUrl("")
+                .build());
+
+        project = projectRepository.save(LectureProject.builder()
+                .name("project-name")
+                .department(department)
+                .startDate(LocalDate.of(2022, 7, 4))
+                .endDate(LocalDate.of(2022, 8, 28))
+                .lectureTimes(Set.of(LectureTime.builder().dayOfWeek(DayOfWeek.MON).startTime(LocalTime.of(9, 0)).build()))
+                .professor("test-professor")
+                .build()
+        );
+
+        recruiting = recruitingRepository.save(Recruiting.builder()
+                .member(member)
+                .project(project)
+                .title("test-title")
+                .content("test-content")
+                .recruitingMemberCount(4)
+                .recruitingType(Type.LECTURE)
+                .activityArea(ActivityArea.ONLINE)
+                .status(ProgressStatus.IN_PROGRESS)
+                .commentCount(0)
+                .bookmarkCount(0)
+                .poolUpCount(0)
+                .introLink("test-introLink")
+                .build()
+        );
+
+        em.flush();
+        em.clear();
+    }
     @DisplayName("신규 댓글을 작성합니다.")
     @Test
     void create() {
         //given
-        Member member = mock(Member.class);
-        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
+        CommentCreation.RequestDto request = new CommentCreation.RequestDto();
+        request.setContent("모집글의 댓글입니다.");
+        request.setParentId(0L);
+        Comment dtoToComment = request.toEntity(member, recruiting);
 
-        Recruiting recruiting = mock(Recruiting.class);
-        when(recruitingRepository.findById(anyLong())).thenReturn(Optional.of(recruiting));
-
-        CommentCreation.RequestDto commentRequest = createCommentRequest();
-        Comment createdComment = mock(Comment.class, RETURNS_DEEP_STUBS);
-        when(commentRepository.save(any(Comment.class))).thenReturn(createdComment);
-
-        //when
-        CommentCreation.ResponseDto response = commentService.addComment(MEMBER_ID, commentRequest);
+        // when
+        CommentCreation.ResponseDto response = commentService.addComment(recruiting.getId(), account.getEmail(), request);
 
         //then
+        Comment createdComment = commentRepository.findById(response.getId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글"));
+        Recruiting updatedRecruiting = recruitingRepository.findById(recruiting.getId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 모집글"));
+
         assertThat(response.getId()).isEqualTo(createdComment.getId());
+        assertThat(dtoToComment.getContent()).isEqualTo(createdComment.getContent());
+        assertThat(dtoToComment.getParentId()).isEqualTo(createdComment.getParentId());
+        assertThat(updatedRecruiting.getCommentCount()).isEqualTo(1);
     }
 
 }


### PR DESCRIPTION
# 구현 내용/방법
- 댓글 등록 시 **모집글의 댓글 갯수 증가 로직** 추가
- 그 외 리팩토링
  - `Domain`과 `ErrorCode` : 이전 커밋에서 추가했던 Exception에서 필요한 도메인과 에러코드 추가
  - `MemberUtils` 이용하도록 코드 수정
  - `memberId`를 dto 요청 -> SecurityContextHolder에서 조회하도록 수정  (그에 따른 CommentFactoryClass와 Comment 테스트 코드 수정) 
  - `CommentServiceTest`를 직접 db와 연결해서 테스트하도록 수정

# 리뷰 필요
- 코멘트 로직 수정하면서 함께 커밋되지 않으면 문제가 있을 것 같은 파일들도 함께 수정해서 커밋합니다 😂 

close #65
