### PR TITLE
Feature/#75 내 팀플 목록 조회 기능 추가

### DIFF
--- a/src/docs/asciidoc/project.adoc
+++ b/src/docs/asciidoc/project.adoc
@@ -1,0 +1,15 @@
+= Project (팀플)
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+:operation-http-request-title: Example request
+:operation-http-response-title: Example response
+
+
+[[get-my-project-list]]
+== 내 팀플 목록 조회
+
+operation::get-my-project-list[snippets='http-request,request-parameters,http-response,response-fields-data']

--- a/src/main/java/com/dnd/niceteam/common/dto/Pagination.java
+++ b/src/main/java/com/dnd/niceteam/common/dto/Pagination.java
@@ -16,9 +16,9 @@ public class Pagination<T> {
 
     private final int perSize;
 
-    private final int totalCount;
+    private final long totalCount;
 
-    private final int totalPages;
+    private final long totalPages;
 
     private final boolean prev;
 
@@ -27,7 +27,7 @@ public class Pagination<T> {
     private final List<T> contents;
 
     @Builder
-    private Pagination(int page, int perSize, int totalCount, List<T> contents) {
+    private Pagination(int page, int perSize, long totalCount, List<T> contents) {
         this.page = page;
         this.perSize = perSize;
         this.totalCount = totalCount;
@@ -35,8 +35,8 @@ public class Pagination<T> {
         this.contents = Objects.requireNonNullElseGet(contents, ArrayList::new);
 
         // 연산된 값
-        int pageWithFullContent = totalCount / perSize;
-        int pageWithLackContent = totalCount % perSize == 0 ? 0 : 1;
+        long pageWithFullContent = totalCount / perSize;
+        long pageWithLackContent = totalCount % perSize == 0 ? 0 : 1;
         this.totalPages = pageWithFullContent + pageWithLackContent;
 
         this.prev = page > 1;

--- a/src/main/java/com/dnd/niceteam/domain/project/Project.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/Project.java
@@ -46,9 +46,12 @@ public abstract class Project extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ProjectStatus status = ProjectStatus.NOT_STARTED;
 
+    @Column(name = "member_count", nullable = false)
+    private Integer memberCount = 0;
+
     @BatchSize(size = 100)
     @OneToMany(mappedBy = "project")
-    private Set<ProjectMember> projectMembers = new HashSet<>();
+    private final Set<ProjectMember> projectMembers = new HashSet<>();
 
     protected Project(@NonNull String name, @NonNull LocalDate startDate, @NonNull LocalDate endDate) {
         this.name = name;
@@ -62,6 +65,7 @@ public abstract class Project extends BaseEntity {
                 .member(member)
                 .build();
         projectMembers.add(projectMember);
+        memberCount += 1;
     }
 
     public void setName(String name) {

--- a/src/main/java/com/dnd/niceteam/domain/project/ProjectRepository.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/ProjectRepository.java
@@ -1,7 +1,8 @@
 package com.dnd.niceteam.domain.project;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface ProjectRepository extends JpaRepository<Project, Long> {
+public interface ProjectRepository extends JpaRepository<Project, Long>, JpaSpecificationExecutor<Project> {
 
 }

--- a/src/main/java/com/dnd/niceteam/domain/project/ProjectSpecification.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/ProjectSpecification.java
@@ -1,0 +1,18 @@
+package com.dnd.niceteam.domain.project;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import javax.persistence.criteria.JoinType;
+
+public class ProjectSpecification {
+
+    public static Specification<Project> equalMemberId(Long memberId) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.join("projectMembers", JoinType.INNER).get("member").get("id"), memberId);
+    }
+
+    public static Specification<Project>  equalStatus(ProjectStatus status) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("status"), status);
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/project/controller/ProjectController.java
+++ b/src/main/java/com/dnd/niceteam/project/controller/ProjectController.java
@@ -1,0 +1,36 @@
+package com.dnd.niceteam.project.controller;
+
+import com.dnd.niceteam.common.dto.ApiResult;
+import com.dnd.niceteam.common.dto.Pagination;
+import com.dnd.niceteam.domain.project.ProjectStatus;
+import com.dnd.niceteam.project.dto.ProjectResponse;
+import com.dnd.niceteam.project.service.ProjectService;
+import com.dnd.niceteam.security.CurrentUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/projects")
+@RequiredArgsConstructor
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResult<Pagination<ProjectResponse.ListItem>>> myProjectList(
+            @RequestParam(defaultValue = "1", required = false) Integer page,
+            @RequestParam(defaultValue = "10", required = false) Integer perSize,
+            @RequestParam(required = false) ProjectStatus status,
+            @CurrentUser User currentUser
+    ) {
+        Pagination<ProjectResponse.ListItem> projects = projectService.getProjectList(page, perSize, status, currentUser);
+        ApiResult<Pagination<ProjectResponse.ListItem>> apiResult = ApiResult.success(projects);
+        return ResponseEntity.ok(apiResult);
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/project/dto/LectureTimeResponse.java
+++ b/src/main/java/com/dnd/niceteam/project/dto/LectureTimeResponse.java
@@ -1,0 +1,25 @@
+package com.dnd.niceteam.project.dto;
+
+import com.dnd.niceteam.domain.code.DayOfWeek;
+import com.dnd.niceteam.domain.project.LectureTime;
+import lombok.Data;
+
+import java.time.LocalTime;
+
+@Data
+public class LectureTimeResponse {
+
+        private DayOfWeek dayOfWeek;
+
+        private LocalTime startTime;
+
+        public static LectureTimeResponse from(LectureTime lectureTime) {
+                LectureTimeResponse dto = new LectureTimeResponse();
+
+                dto.setDayOfWeek(lectureTime.getDayOfWeek());
+                dto.setStartTime(lectureTime.getStartTime());
+
+                return dto;
+        }
+
+}

--- a/src/main/java/com/dnd/niceteam/project/dto/ProjectResponse.java
+++ b/src/main/java/com/dnd/niceteam/project/dto/ProjectResponse.java
@@ -2,6 +2,7 @@ package com.dnd.niceteam.project.dto;
 
 import com.dnd.niceteam.domain.code.Field;
 import com.dnd.niceteam.domain.code.FieldCategory;
+import com.dnd.niceteam.domain.code.Type;
 import com.dnd.niceteam.domain.project.LectureProject;
 import com.dnd.niceteam.domain.project.Project;
 import com.dnd.niceteam.domain.project.ProjectStatus;
@@ -10,6 +11,8 @@ import lombok.Data;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public interface ProjectResponse {
 
@@ -20,14 +23,17 @@ public interface ProjectResponse {
 
         // Project 상태
         private String name;
-        private ProjectStatus status;
+        private Type type;
 
         private LocalDate startDate;
         private LocalDate endDate;
 
+        private ProjectStatus status;
+
         // Lecture Project 상태
         private String professor;
         private DepartmentResponse department;
+        private List<LectureTimeResponse> lectureTimes;
 
         // Side Project
         private Field field;
@@ -39,18 +45,26 @@ public interface ProjectResponse {
         private String createdBy;
         private String lastModifiedBy;
 
-        public static ProjectResponse.Detail from(LectureProject lecture) {
-            ProjectResponse.Detail dto = setProjectCommonDetails(lecture);
+        public static Detail from(LectureProject lecture) {
+            Detail dto = new Detail();
+
+            List<LectureTimeResponse> lectureTimes = lecture.getLectureTimes().stream()
+                    .map(LectureTimeResponse::from).collect(Collectors.toList());
+
+            setProjectCommonDetails(lecture, dto);
 
             // Lecture Project 상태
             dto.setProfessor(lecture.getProfessor());
             dto.setDepartment(DepartmentResponse.from(lecture.getDepartment()));
+            dto.setLectureTimes(lectureTimes);
 
             return dto;
         }
 
-        public static ProjectResponse.Detail from(SideProject side) {
-            ProjectResponse.Detail dto = setProjectCommonDetails(side);
+        public static Detail from(SideProject side) {
+            Detail dto = new Detail();
+
+            setProjectCommonDetails(side, dto);
 
             // Side Project 상태
             dto.setField(side.getField());
@@ -59,12 +73,12 @@ public interface ProjectResponse {
             return dto;
         }
 
-        private static ProjectResponse.Detail setProjectCommonDetails(Project project) {
-            ProjectResponse.Detail dto = new ProjectResponse.Detail();
+        private static void setProjectCommonDetails(Project project, Detail dto) {
             dto.setId(project.getId());
 
             // Project 상태
             dto.setName(project.getName());
+            dto.setType(project.getType());
             dto.setStatus(project.getStatus());
 
             dto.setStartDate(project.getStartDate());
@@ -75,8 +89,74 @@ public interface ProjectResponse {
             dto.setLastModifiedDate(project.getLastModifiedDate());
             dto.setCreatedBy(project.getCreatedBy());
             dto.setLastModifiedBy(project.getLastModifiedBy());
+        }
+
+    }
+
+    @Data
+    class ListItem {
+
+        private Long id;
+
+        // Project 상태
+        private String name;
+        private Type type;
+
+        private LocalDate startDate;
+        private LocalDate endDate;
+
+        private ProjectStatus status;
+
+        private Integer memberCount;
+
+        // Lecture Project 상태
+        private String professor;
+        private DepartmentResponse department;
+        private List<LectureTimeResponse> lectureTimes;
+
+        // Side Project
+        private Field field;
+        private FieldCategory fieldCategory;
+
+        public static ListItem of(Project project) {
+            ListItem dto = new ListItem();
+
+            dto.setId(project.getId());
+
+            // Project 상태
+            dto.setName(project.getName());
+            dto.setType(project.getType());
+            dto.setStatus(project.getStatus());
+
+            dto.setStartDate(project.getStartDate());
+            dto.setEndDate(project.getEndDate());
+
+            // 계산된 값
+            dto.setMemberCount(project.getMemberCount());
+
+            if (project.getType() == Type.LECTURE) {
+                setLectureDetails((LectureProject) project, dto);
+            } else {
+                setSideDetails((SideProject) project, dto);
+            }
 
             return dto;
+        }
+
+        public static void setLectureDetails(LectureProject lecture, ListItem dto) {
+            List<LectureTimeResponse> lectureTimes = lecture.getLectureTimes().stream()
+                    .map(LectureTimeResponse::from).collect(Collectors.toList());
+
+            // Lecture Project 상태
+            dto.setProfessor(lecture.getProfessor());
+            dto.setDepartment(DepartmentResponse.from(lecture.getDepartment()));
+            dto.setLectureTimes(lectureTimes);
+        }
+
+        public static void setSideDetails(SideProject side, ListItem dto) {
+            // Side Project 상태
+            dto.setField(side.getField());
+            dto.setFieldCategory(side.getFieldCategory());
         }
 
     }

--- a/src/main/java/com/dnd/niceteam/project/service/ProjectService.java
+++ b/src/main/java/com/dnd/niceteam/project/service/ProjectService.java
@@ -1,20 +1,31 @@
 package com.dnd.niceteam.project.service;
 
+import com.dnd.niceteam.common.dto.Pagination;
 import com.dnd.niceteam.domain.code.Type;
 import com.dnd.niceteam.domain.department.Department;
 import com.dnd.niceteam.domain.department.DepartmentRepository;
 import com.dnd.niceteam.domain.department.exception.DepartmentNotFoundException;
+import com.dnd.niceteam.domain.member.Member;
+import com.dnd.niceteam.domain.member.MemberRepository;
 import com.dnd.niceteam.domain.project.*;
+import com.dnd.niceteam.member.util.MemberUtils;
 import com.dnd.niceteam.project.dto.LectureTimeRequest;
 import com.dnd.niceteam.project.dto.ProjectRequest;
 import com.dnd.niceteam.project.dto.ProjectResponse;
 import com.dnd.niceteam.project.exception.InvalidProjectSchedule;
 import com.dnd.niceteam.project.exception.ProjectNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -27,6 +38,7 @@ public class ProjectService {
     private final LectureProjectRepository lectureSideProjectRepository;
     private final SideProjectRepository sideProjectRepository;
     private final DepartmentRepository departmentRepository;
+    private final MemberRepository memberRepository;
     
     // TODO: 기획 논의 후 startDate, endDate에 @Past, @Future 등의 유효성검사 어노테이션 붙이기
     @Transactional
@@ -48,7 +60,20 @@ public class ProjectService {
         modifyProject(project, request);
     }
 
+    public Pagination<ProjectResponse.ListItem> getProjectList(int page, int perSize, ProjectStatus status, User currentUser) {
+        Member currentMember = MemberUtils.findMemberByEmail(currentUser.getUsername(), memberRepository);
+
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
+        Pageable pageable = PageRequest.of(page - 1, perSize, sort);
+
+        Specification<Project> spec = getProjectListSearchSpecs(currentMember.getId(), status);
+
+        Page<Project> projectPages = projectRepository.findAll(spec, pageable);
+        return mapProjectPagination(projectPages);
+    }
+
     /* private 메서드 */
+    // 프로젝트 등록 관련
     private ProjectResponse.Detail saveProject(ProjectRequest.Register request) {
         if (request.getType() == Type.LECTURE) {
             return ProjectResponse.Detail.from(saveLectureProject(request));
@@ -57,6 +82,7 @@ public class ProjectService {
         }
     }
 
+    // 프로젝트 수정 관련
     private void modifyProject(Project project, ProjectRequest.Update request) {
         project.setName(request.getName());
         project.setStartDate(request.getStartDate());
@@ -67,9 +93,9 @@ public class ProjectService {
     }
 
     private void modifyLectureProject(LectureProject lectureProject, ProjectRequest.Update request) {
-        Department newDepartment =          departmentRepository.getReferenceById(request.getDepartmentId());
-        Set<LectureTime> lectureTimeSet =   request.getLectureTimes().stream()
-                                                .map(LectureTimeRequest::toEntity).collect(Collectors.toSet());
+        Department newDepartment =                  departmentRepository.getReferenceById(request.getDepartmentId());
+        Set<LectureTime> lectureTimeSet =           request.getLectureTimes().stream()
+                                                        .map(LectureTimeRequest::toEntity).collect(Collectors.toSet());
 
         lectureProject.setDepartment(newDepartment);
         lectureProject.setProfessor(request.getProfessor());
@@ -79,6 +105,29 @@ public class ProjectService {
     private void modifySideProject(SideProject sideProject, ProjectRequest.Update request) {
         sideProject.setField(request.getField());
         sideProject.setFieldCategory(request.getFieldCategory());
+    }
+
+    // 프로젝트 목록 조회 관련
+    private Specification<Project> getProjectListSearchSpecs(Long memberId, ProjectStatus status) {
+        Specification<Project> spec = (root, query, criteriaBuilder) -> null;
+        spec = spec.and(ProjectSpecification.equalMemberId(memberId));
+        if (status != null)  spec = spec.and(ProjectSpecification.equalStatus(status));
+
+        return spec;
+    }
+
+    private Pagination<ProjectResponse.ListItem> mapProjectPagination(Page<Project> projectPages) {
+        Pageable pageable = projectPages.getPageable();
+
+        List<ProjectResponse.ListItem> projectList = projectPages
+                .stream().map(ProjectResponse.ListItem::of).collect(Collectors.toList());
+
+        return Pagination.<ProjectResponse.ListItem>builder()
+                .page(pageable.getPageNumber() + 1)
+                .perSize(pageable.getPageSize())
+                .totalCount(projectPages.getTotalElements())
+                .contents(projectList)
+                .build();
     }
 
     /* JPA 메서드 */
@@ -99,5 +148,4 @@ public class ProjectService {
         return projectRepository.findById(projectId)
                 .orElseThrow(() -> new ProjectNotFoundException("id = " + projectId));
     }
-
 }

--- a/src/test/java/com/dnd/niceteam/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/dnd/niceteam/project/controller/ProjectControllerTest.java
@@ -1,0 +1,126 @@
+package com.dnd.niceteam.project.controller;
+
+import com.dnd.niceteam.common.RestDocsConfig;
+import com.dnd.niceteam.common.dto.Pagination;
+import com.dnd.niceteam.domain.project.ProjectStatus;
+import com.dnd.niceteam.project.dto.LectureTimeResponse;
+import com.dnd.niceteam.project.dto.ProjectResponse;
+import com.dnd.niceteam.project.service.ProjectService;
+import com.dnd.niceteam.security.SecurityConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(RestDocsConfig.class)
+@AutoConfigureRestDocs
+@WebMvcTest(
+        controllers = ProjectController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+        })
+class ProjectControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ProjectService projectService;
+
+    @Test
+    @WithMockUser
+    @DisplayName("프로젝트 목록 조회")
+    void addMemberReview() throws Exception {
+        // given
+        ProjectResponse.ListItem projectListItem = mock(ProjectResponse.ListItem.class, RETURNS_DEEP_STUBS);
+        when(projectListItem.getLectureTimes()).thenReturn(List.of(mock(LectureTimeResponse.class)));
+
+        given(projectService.getProjectList(anyInt(), anyInt(), any(ProjectStatus.class), any(User.class))).willReturn(
+                Pagination.<ProjectResponse.ListItem>builder()
+                        .page(1)
+                        .perSize(10)
+                        .totalCount(1)
+                        .contents(List.of(projectListItem))
+                        .build()
+        );
+
+        // then
+        mockMvc.perform(
+                        get("/projects/me")
+                                .accept(MediaType.APPLICATION_JSON)
+                                .param("page", "1")
+                                .param("perSize", "10")
+                                .param("status", ProjectStatus.NOT_STARTED.name())
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isNotEmpty())
+                .andDo(
+                        document("get-my-project-list",
+                                requestParameters(
+                                        parameterWithName("page").description("현재 페이지"),
+                                        parameterWithName("perSize").description("페이지 아이템 개수"),
+                                        parameterWithName("status").description("프로젝트 진행 상태")
+                                ),
+                                responseFields(
+                                        beneathPath("data").withSubsectionId("data"),
+                                        fieldWithPath("page").description("현재 페이지"),
+                                        fieldWithPath("perSize").description("페이지 아이템 개수"),
+                                        fieldWithPath("totalCount").description("총 아이템 개수"),
+                                        fieldWithPath("totalPages").description("총 페이지 개수"),
+                                        fieldWithPath("prev").description("이전 페이지 존재 여부"),
+                                        fieldWithPath("next").description("다음 페이지 존재 여부"),
+                                        fieldWithPath("contents[].id").description("프로젝트 식별자"),
+                                        fieldWithPath("contents[].name").description("프로젝트명"),
+                                        fieldWithPath("contents[].type").description("프로젝트 종류"),
+                                        fieldWithPath("contents[].startDate").description("프로젝트 시작일"),
+                                        fieldWithPath("contents[].endDate").description("프로젝트 종료일"),
+                                        fieldWithPath("contents[].status").description("프로젝트 진행 상태"),
+                                        fieldWithPath("contents[].memberCount").description("팀원 수"),
+                                        fieldWithPath("contents[].professor").description("교수명"),
+                                        fieldWithPath("contents[].department.id").description("학과 식별자"),
+                                        fieldWithPath("contents[].department.collegeName").description("단과대학 이름"),
+                                        fieldWithPath("contents[].department.name").description("학과 이름"),
+                                        fieldWithPath("contents[].department.mainBranchType").description("주 캠퍼스 여부"),
+                                        fieldWithPath("contents[].department.region").description("지역"),
+                                        fieldWithPath("contents[].department.university.id").description("대학교 식별자"),
+                                        fieldWithPath("contents[].department.university.name").description("대학교 이름"),
+                                        fieldWithPath("contents[].department.university.emailDomain").description("대학교 이메일 도메인"),
+                                        fieldWithPath("contents[].lectureTimes[].dayOfWeek").description("활동 요일"),
+                                        fieldWithPath("contents[].lectureTimes[].startTime").description("시작 시간"),
+                                        fieldWithPath("contents[].field").description("관심 분야"),
+                                        fieldWithPath("contents[].fieldCategory").description("관심 분야 카테고리")
+                                )
+                        )
+                );
+    }
+
+}


### PR DESCRIPTION
# 구현 내용/방법

- 내 팀플 목록을 조회하는 API를 추가했어요
- 페이지네이션을 적용했어요
- 강의 팀플 / 사이드 팀플 여부에 따라 필터링되도록 JPA Specification을 이용해 Criteria API로 JPQL을 적용했어요

close #75
