### PR TITLE
Feature/#34 내 팀플 상세 조회 기능 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -17,6 +17,8 @@
 - xref:applicant.adoc[Applicant (지원자)]
 - xref:comment.adoc[Comment (댓글 및 답글)]
 - xref:bookmark.adoc[Bookmark (북마크)]
+- xref:bookmark.adoc[Member Review (팀원 후기)]
+- xref:bookmark.adoc[Project (팀플)]
 
 
 == HTTP Method

--- a/src/docs/asciidoc/project.adoc
+++ b/src/docs/asciidoc/project.adoc
@@ -13,3 +13,9 @@
 == 내 팀플 목록 조회
 
 operation::get-my-project-list[snippets='http-request,request-parameters,http-response,response-fields-data']
+
+
+[[get-my-project]]
+== 내 팀플 목록 조회
+
+operation::get-my-project[snippets='http-request,request-parameters,http-response,response-fields-data']

--- a/src/main/java/com/dnd/niceteam/domain/project/ProjectRepository.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/ProjectRepository.java
@@ -4,5 +4,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface ProjectRepository extends JpaRepository<Project, Long>, JpaSpecificationExecutor<Project> {
-
 }

--- a/src/main/java/com/dnd/niceteam/domain/project/ProjectSpecification.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/ProjectSpecification.java
@@ -15,4 +15,7 @@ public class ProjectSpecification {
         return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("status"), status);
     }
 
+    public static Specification<Project> equalProjectId(Long projectId) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("id"), projectId);
+    }
 }

--- a/src/main/java/com/dnd/niceteam/project/controller/ProjectController.java
+++ b/src/main/java/com/dnd/niceteam/project/controller/ProjectController.java
@@ -9,10 +9,7 @@ import com.dnd.niceteam.security.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/projects")
@@ -30,6 +27,16 @@ public class ProjectController {
     ) {
         Pagination<ProjectResponse.ListItem> projects = projectService.getProjectList(page, perSize, status, currentUser);
         ApiResult<Pagination<ProjectResponse.ListItem>> apiResult = ApiResult.success(projects);
+        return ResponseEntity.ok(apiResult);
+    }
+
+    @GetMapping("/{projectId}")
+    public ResponseEntity<ApiResult<ProjectResponse.Detail>> projectDetails(
+            @PathVariable Long projectId,
+            @CurrentUser User currentUser
+    ) {
+        ProjectResponse.Detail response = projectService.getProject(projectId, currentUser);
+        ApiResult<ProjectResponse.Detail> apiResult = ApiResult.success(response);
         return ResponseEntity.ok(apiResult);
     }
 

--- a/src/main/java/com/dnd/niceteam/project/dto/PersonalityResponse.java
+++ b/src/main/java/com/dnd/niceteam/project/dto/PersonalityResponse.java
@@ -1,0 +1,25 @@
+package com.dnd.niceteam.project.dto;
+
+import com.dnd.niceteam.domain.code.Personality;
+import lombok.Data;
+
+@Data
+public class PersonalityResponse {
+
+    private Personality.Adjective adjective;
+    private Personality.Noun noun;
+
+    public String getTag() {
+        return String.format("%s %s", adjective.getTitle(), noun.getTitle());
+    }
+
+    public static PersonalityResponse from(Personality personality) {
+        PersonalityResponse dto = new PersonalityResponse();
+
+        dto.setAdjective(personality.getAdjective());
+        dto.setNoun(personality.getNoun());
+
+        return dto;
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/project/dto/ProjectMemberResponse.java
+++ b/src/main/java/com/dnd/niceteam/project/dto/ProjectMemberResponse.java
@@ -1,0 +1,39 @@
+package com.dnd.niceteam.project.dto;
+
+import com.dnd.niceteam.domain.member.Member;
+import com.dnd.niceteam.domain.project.ProjectMember;
+import lombok.Data;
+
+public interface ProjectMemberResponse {
+
+    @Data
+    class Summary {
+
+        private long memberId;
+
+        private String nickname;
+
+        private int admissionYear;
+
+        private PersonalityResponse personality;
+
+        private boolean expelled;
+
+        public static Summary from(ProjectMember projectMember) {
+            Member member = projectMember.getMember();
+            PersonalityResponse personalityResponse = PersonalityResponse.from(member.getPersonality());
+
+            Summary dto = new Summary();
+
+            dto.setMemberId(projectMember.getId());
+            dto.setNickname(member.getNickname());
+            dto.setAdmissionYear(member.getAdmissionYear());
+            dto.setPersonality(personalityResponse);
+            dto.setExpelled(projectMember.getExpelled());
+
+            return dto;
+        }
+
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/project/dto/ProjectResponse.java
+++ b/src/main/java/com/dnd/niceteam/project/dto/ProjectResponse.java
@@ -29,6 +29,8 @@ public interface ProjectResponse {
         private LocalDate endDate;
 
         private ProjectStatus status;
+        private Integer memberCount;
+        private List<ProjectMemberResponse.Summary> memberList;
 
         // Lecture Project 상태
         private String professor;
@@ -44,6 +46,11 @@ public interface ProjectResponse {
         private LocalDateTime lastModifiedDate;
         private String createdBy;
         private String lastModifiedBy;
+
+        public static Detail from(Project project) {
+            return project.getType() == Type.LECTURE ?
+                    from((LectureProject) project) : from((SideProject) project);
+        }
 
         public static Detail from(LectureProject lecture) {
             Detail dto = new Detail();
@@ -74,6 +81,9 @@ public interface ProjectResponse {
         }
 
         private static void setProjectCommonDetails(Project project, Detail dto) {
+            List<ProjectMemberResponse.Summary> memberList = project.getProjectMembers().stream()
+                    .map(ProjectMemberResponse.Summary::from).collect(Collectors.toList());
+
             dto.setId(project.getId());
 
             // Project 상태
@@ -83,6 +93,9 @@ public interface ProjectResponse {
 
             dto.setStartDate(project.getStartDate());
             dto.setEndDate(project.getEndDate());
+
+            dto.setMemberCount(project.getMemberCount());
+            dto.setMemberList(memberList);
 
             // Auditing 정보
             dto.setCreatedDate(project.getCreatedDate());


### PR DESCRIPTION
# 구현 내용/방법

- 1) ProjectSpecification에 equalProjectId 조건을 추가했어요!
- 2) 조회하려는 Project의 멤버 목록에 로그인된 member가 없을 경우 404 Not Found를 반환해요
- 3) 반환 시 팀플 팀원 수와 팀원 목록, 각 팀원 성향 정보를 함께 되돌려주도록 수정했어요
- 4) 강의 팀플인지, 사이드 팀플인지에 따라 프론트에 다른 JSON을 응답해줘요

close #34
