### PR TITLE
Feature/#80 팀원 내보내기 투표 기능 추가

### DIFF
--- a/src/docs/asciidoc/vote.adoc
+++ b/src/docs/asciidoc/vote.adoc
@@ -1,0 +1,15 @@
+= Vote (투표)
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+:operation-http-request-title: Example request
+:operation-http-response-title: Example response
+
+
+[[vote]]
+== 투표 표 등록
+
+operation::vote[snippets='http-request,request-parameters,http-response,response-fields-data']

--- a/src/main/java/com/dnd/niceteam/common/Domain.java
+++ b/src/main/java/com/dnd/niceteam/common/Domain.java
@@ -12,6 +12,8 @@ public enum Domain {
 
     PROJECT,
     PROJECT_MEMBER,
+    VOTE_GROUP,
+    VOTE,
 
     RECRUITING,
     COMMENT,

--- a/src/main/java/com/dnd/niceteam/domain/code/VoteType.java
+++ b/src/main/java/com/dnd/niceteam/domain/code/VoteType.java
@@ -11,6 +11,6 @@ public enum VoteType {
     , EXPEL("내보내기 투표")
     ;
 
-    private final String kor;
+    private final String title;
 
 }

--- a/src/main/java/com/dnd/niceteam/domain/code/VoteType.java
+++ b/src/main/java/com/dnd/niceteam/domain/code/VoteType.java
@@ -1,4 +1,4 @@
-package com.dnd.niceteam.domain.vote;
+package com.dnd.niceteam.domain.code;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum VoteType {
 
     PROJECT_COMPLETE("팀플 완료 투표")
-    , KICK("내보내기 투표")
+    , EXPEL("내보내기 투표")
     ;
 
     private final String kor;

--- a/src/main/java/com/dnd/niceteam/domain/vote/Vote.java
+++ b/src/main/java/com/dnd/niceteam/domain/vote/Vote.java
@@ -11,7 +11,6 @@ import javax.persistence.*;
 
 @Entity
 @Getter
-@Builder
 @Table(name = "vote")
 @SQLDelete(sql = "UPDATE vote SET use_yn = false WHERE id = ?")
 @Where(clause = "use_yn = true")
@@ -33,6 +32,15 @@ public class Vote extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "project_member_id", nullable = false)
-    private ProjectMember projectMember;
+    private ProjectMember voter;
+
+    @Builder
+    private Vote(boolean choice, @NonNull VoteGroup voteGroup, @NonNull ProjectMember voter) {
+        this.choice = choice;
+        this.voteGroup = voteGroup;
+        this.voter = voter;
+
+        voteGroup.addVote(this);
+    }
 
 }

--- a/src/main/java/com/dnd/niceteam/domain/vote/VoteGroup.java
+++ b/src/main/java/com/dnd/niceteam/domain/vote/VoteGroup.java
@@ -6,10 +6,13 @@ import io.jsonwebtoken.lang.Assert;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -33,10 +36,24 @@ public abstract class VoteGroup extends BaseEntity {
     @JoinColumn(name = "project_id", nullable = false)
     private Project project;
 
-    public VoteGroup(Project project) {
+    @BatchSize(size = 100)
+    @OneToMany(mappedBy = "voteGroup")
+    private final List<Vote> votes = new ArrayList<>();
+
+    protected VoteGroup(Project project) {
         Assert.notNull(project, "project는 필수 값입니다.");
 
         this.project = project;
     }
+
+    public void addVote(Vote vote) {
+        this.votes.add(vote);
+    }
+
+    public void checkComplete() {
+        if (isVoteCompleted()) complete = true;
+    }
+
+    protected abstract boolean isVoteCompleted();
 
 }

--- a/src/main/java/com/dnd/niceteam/domain/vote/VoteGroupToCompleteProject.java
+++ b/src/main/java/com/dnd/niceteam/domain/vote/VoteGroupToCompleteProject.java
@@ -23,4 +23,12 @@ public class VoteGroupToCompleteProject extends VoteGroup {
         super(project);
     }
 
+    @Override
+    protected boolean isVoteCompleted() {
+        int numOfMembers = this.getProject().getProjectMembers().size();
+        int numOfVotes = this.getVotes().size();
+
+        return numOfMembers == numOfVotes;
+    }
+
 }

--- a/src/main/java/com/dnd/niceteam/domain/vote/VoteGroupToExpel.java
+++ b/src/main/java/com/dnd/niceteam/domain/vote/VoteGroupToExpel.java
@@ -19,7 +19,7 @@ import javax.persistence.*;
 @OnDelete(action = OnDeleteAction.CASCADE)
 public class VoteGroupToExpel extends VoteGroup {
 
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "candidate_id", nullable = false)
     private ProjectMember candidate;
 
@@ -37,8 +37,6 @@ public class VoteGroupToExpel extends VoteGroup {
     protected boolean isVoteCompleted() {
         int numOfMembers = this.getProject().getProjectMembers().size();
         int numOfVotes = this.getVotes().size();
-
-        System.out.println("추방 : " + numOfMembers + " / " + numOfVotes);
 
         return numOfMembers - 1 == numOfVotes;
     }

--- a/src/main/java/com/dnd/niceteam/domain/vote/VoteGroupToExpel.java
+++ b/src/main/java/com/dnd/niceteam/domain/vote/VoteGroupToExpel.java
@@ -20,16 +20,27 @@ import javax.persistence.*;
 public class VoteGroupToExpel extends VoteGroup {
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "project_member_id", nullable = false)
-    private ProjectMember projectMember;
+    @JoinColumn(name = "candidate_id", nullable = false)
+    private ProjectMember candidate;
 
     @Builder
-    public VoteGroupToExpel(Project project, ProjectMember projectMember) {
+    public VoteGroupToExpel(Project project, ProjectMember candidate) {
         super(project);
 
-        Assert.notNull(projectMember, "projectMember는 필수 값입니다.");
+        Assert.notNull(candidate, "projectMember는 필수 값입니다.");
 
-        this.projectMember = projectMember;
+        this.candidate = candidate;
+    }
+
+    /* @Override 메서드 */
+    @Override
+    protected boolean isVoteCompleted() {
+        int numOfMembers = this.getProject().getProjectMembers().size();
+        int numOfVotes = this.getVotes().size();
+
+        System.out.println("추방 : " + numOfMembers + " / " + numOfVotes);
+
+        return numOfMembers - 1 == numOfVotes;
     }
 
 }

--- a/src/main/java/com/dnd/niceteam/domain/vote/VoteGroupToExpelRepository.java
+++ b/src/main/java/com/dnd/niceteam/domain/vote/VoteGroupToExpelRepository.java
@@ -1,0 +1,19 @@
+package com.dnd.niceteam.domain.vote;
+
+import com.dnd.niceteam.domain.project.Project;
+import com.dnd.niceteam.domain.project.ProjectMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface VoteGroupToExpelRepository extends JpaRepository<VoteGroupToExpel, Long> {
+
+    Optional<VoteGroupToExpel> findByProjectAndCandidateAndCreatedDateGreaterThan(
+            @Param("project") Project project,
+            @Param("candidate") ProjectMember candidate,
+            @Param("createdDate")LocalDateTime createdDate
+    );
+
+}

--- a/src/main/java/com/dnd/niceteam/domain/vote/VoteRepository.java
+++ b/src/main/java/com/dnd/niceteam/domain/vote/VoteRepository.java
@@ -1,0 +1,10 @@
+package com.dnd.niceteam.domain.vote;
+
+import com.dnd.niceteam.domain.project.ProjectMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+
+    boolean existsByVoteGroupAndVoter(VoteGroup voteGroup, ProjectMember voter);
+
+}

--- a/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
@@ -53,6 +53,12 @@ public enum ErrorCode {
     BOOKMARK_NOT_OWNED(BOOKMARK, SC_BAD_REQUEST, "소유하지 않은 북마크입니다."),
     
     APPLY_ALREADY_ACCEPTED(APPLICANT, SC_BAD_REQUEST, "이미 수락된 지원입니다."),
+    
+    // Vote
+    EXPIRED_VOTE_GROUP(VOTE_GROUP, SC_BAD_REQUEST, "내보내기 투표 기간이 만료되었습니다."),
+    ALREADY_VOTED(VOTE, SC_BAD_REQUEST, "이미 투표에 참여하셨습니다."),
+    NOT_ENOUGH_PROJECT_MEMBER(VOTE, SC_BAD_REQUEST, "투표를 하기 위해서는 팀원 수가 3명 이상이어야 합니다."),
+    SELF_VOTE(VOTE, SC_BAD_REQUEST, "자기자신에게는 투표할 수 없습니다."),
     ;
 
     private final Domain domain;

--- a/src/main/java/com/dnd/niceteam/vote/controller/VoteController.java
+++ b/src/main/java/com/dnd/niceteam/vote/controller/VoteController.java
@@ -1,0 +1,33 @@
+package com.dnd.niceteam.vote.controller;
+
+import com.dnd.niceteam.common.dto.ApiResult;
+import com.dnd.niceteam.security.CurrentUser;
+import com.dnd.niceteam.vote.dto.VoteRequest;
+import com.dnd.niceteam.vote.service.VoteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/votes")
+@RequiredArgsConstructor
+public class VoteController {
+
+    private final VoteService voteService;
+
+    @PostMapping
+    public ResponseEntity<ApiResult<Void>> voteAdd(
+            @RequestBody VoteRequest.Add request,
+            @CurrentUser User currentUser
+    ) {
+        voteService.addVote(request, currentUser);
+        ApiResult<Void> apiResult = ApiResult.<Void>success().build();
+        return ResponseEntity.status(HttpStatus.CREATED).body(apiResult);
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/vote/dto/VoteRequest.java
+++ b/src/main/java/com/dnd/niceteam/vote/dto/VoteRequest.java
@@ -1,0 +1,32 @@
+package com.dnd.niceteam.vote.dto;
+
+import com.dnd.niceteam.domain.code.VoteType;
+import com.dnd.niceteam.domain.project.ProjectMember;
+import com.dnd.niceteam.domain.vote.Vote;
+import com.dnd.niceteam.domain.vote.VoteGroup;
+import lombok.Data;
+
+public interface VoteRequest {
+
+    @Data
+    class Add {
+
+        private VoteType type;
+
+        private Long projectId;
+
+        private Long candidateMemberId;
+
+        private Boolean choice;
+
+        public Vote toEntity(VoteGroup voteGroup, ProjectMember voter) {
+            return Vote.builder()
+                    .choice(choice)
+                    .voteGroup(voteGroup)
+                    .voter(voter)
+                    .build();
+        }
+
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/vote/exception/AlreadyVotedException.java
+++ b/src/main/java/com/dnd/niceteam/vote/exception/AlreadyVotedException.java
@@ -1,0 +1,12 @@
+package com.dnd.niceteam.vote.exception;
+
+import com.dnd.niceteam.error.exception.BusinessException;
+import com.dnd.niceteam.error.exception.ErrorCode;
+
+public class AlreadyVotedException extends BusinessException {
+
+    public AlreadyVotedException(Long voteGroupId, Long voterId) {
+        super(ErrorCode.ALREADY_VOTED, String.format("voteGroupId = %d, voterId = %d", voteGroupId, voterId));
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/vote/exception/ExpiredVoteGroupException.java
+++ b/src/main/java/com/dnd/niceteam/vote/exception/ExpiredVoteGroupException.java
@@ -1,0 +1,10 @@
+package com.dnd.niceteam.vote.exception;
+
+import com.dnd.niceteam.error.exception.BusinessException;
+import com.dnd.niceteam.error.exception.ErrorCode;
+
+public class ExpiredVoteGroupException extends BusinessException {
+    public ExpiredVoteGroupException(String message) {
+        super(ErrorCode.EXPIRED_VOTE_GROUP, message);
+    }
+}

--- a/src/main/java/com/dnd/niceteam/vote/exception/ExpiredVoteGroupException.java
+++ b/src/main/java/com/dnd/niceteam/vote/exception/ExpiredVoteGroupException.java
@@ -4,7 +4,7 @@ import com.dnd.niceteam.error.exception.BusinessException;
 import com.dnd.niceteam.error.exception.ErrorCode;
 
 public class ExpiredVoteGroupException extends BusinessException {
-    public ExpiredVoteGroupException(String message) {
-        super(ErrorCode.EXPIRED_VOTE_GROUP, message);
+    public ExpiredVoteGroupException(Long voteGroupId) {
+        super(ErrorCode.EXPIRED_VOTE_GROUP, "voteGroupId = " + voteGroupId);
     }
 }

--- a/src/main/java/com/dnd/niceteam/vote/exception/NotEnoughProjectMembersException.java
+++ b/src/main/java/com/dnd/niceteam/vote/exception/NotEnoughProjectMembersException.java
@@ -1,0 +1,10 @@
+package com.dnd.niceteam.vote.exception;
+
+import com.dnd.niceteam.error.exception.BusinessException;
+import com.dnd.niceteam.error.exception.ErrorCode;
+
+public class NotEnoughProjectMembersException extends BusinessException {
+    public NotEnoughProjectMembersException(Long id) {
+        super(ErrorCode.NOT_ENOUGH_PROJECT_MEMBER, "projectId = " + id);
+    }
+}

--- a/src/main/java/com/dnd/niceteam/vote/exception/SelfVoteException.java
+++ b/src/main/java/com/dnd/niceteam/vote/exception/SelfVoteException.java
@@ -1,0 +1,10 @@
+package com.dnd.niceteam.vote.exception;
+
+import com.dnd.niceteam.error.exception.BusinessException;
+import com.dnd.niceteam.error.exception.ErrorCode;
+
+public class SelfVoteException extends BusinessException {
+    public SelfVoteException(Long memberId) {
+        super(ErrorCode.SELF_VOTE, "memberId = " + memberId);
+    }
+}

--- a/src/main/java/com/dnd/niceteam/vote/service/VoteService.java
+++ b/src/main/java/com/dnd/niceteam/vote/service/VoteService.java
@@ -1,0 +1,114 @@
+package com.dnd.niceteam.vote.service;
+
+import com.dnd.niceteam.domain.code.VoteType;
+import com.dnd.niceteam.domain.member.Member;
+import com.dnd.niceteam.domain.member.MemberRepository;
+import com.dnd.niceteam.domain.project.Project;
+import com.dnd.niceteam.domain.project.ProjectMember;
+import com.dnd.niceteam.domain.project.ProjectRepository;
+import com.dnd.niceteam.domain.vote.*;
+import com.dnd.niceteam.member.util.MemberUtils;
+import com.dnd.niceteam.project.exception.ProjectMemberNotFoundException;
+import com.dnd.niceteam.project.exception.ProjectNotFoundException;
+import com.dnd.niceteam.vote.dto.VoteRequest;
+import com.dnd.niceteam.vote.exception.AlreadyVotedException;
+import com.dnd.niceteam.vote.exception.ExpiredVoteGroupException;
+import com.dnd.niceteam.vote.exception.NotEnoughProjectMembersException;
+import com.dnd.niceteam.vote.exception.SelfVoteException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VoteService {
+
+    private static final int VOTE_DURATION = 7;
+
+    private final VoteGroupToExpelRepository voteGroupToExpelRepository;
+    private final VoteRepository voteRepository;
+    private final MemberRepository memberRepository;
+    private final ProjectRepository projectRepository;
+
+    @Transactional
+    public void addVote(VoteRequest.Add request, User currentUser) {
+        Member currentMember =              MemberUtils.findMemberByEmail(currentUser.getUsername(), memberRepository);
+
+        Project project =                   findProject(request.getProjectId());
+        ProjectMember voter =               findProjectMemberFrom(project, currentMember.getId());
+
+        if (request.getType() == VoteType.EXPEL)    voteToExpelCandidate(project, voter, request);
+    }
+
+    /* private 메서드 */
+    // 내보내기 투표 : 비즈니스 로직
+    private void voteToExpelCandidate(Project project, ProjectMember voter, VoteRequest.Add request) {
+        ProjectMember candidate =           findProjectMemberFrom(project, request.getCandidateMemberId());
+        VoteGroupToExpel voteGroup =        findOrCreateVoteGroupToExpel(project, candidate);
+
+        if (areNotEnoughProjectMembers(project))
+            throw new NotEnoughProjectMembersException(project.getId());
+        if (isSelfVote(voter.getMember().getId(), request.getCandidateMemberId()))
+            throw new SelfVoteException(voter.getMember().getId());
+        if (isVoteGroupExpired(voteGroup))  throw new ExpiredVoteGroupException(voteGroup.getId());
+        if (isVoteGroupAlreadyVoted(voteGroup, voter))
+            throw new AlreadyVotedException(voteGroup.getId(), voter.getId());
+
+        Vote vote =                         request.toEntity(voteGroup, voter);
+        voteRepository.save(vote);
+
+        voteGroup.checkComplete();
+    }
+
+    private VoteGroupToExpel findOrCreateVoteGroupToExpel(Project project, ProjectMember candidate) {
+        LocalDateTime validCreatedDate = LocalDateTime.now().minusDays(VOTE_DURATION);
+
+        return voteGroupToExpelRepository.findByProjectAndCandidateAndCreatedDateGreaterThan(project, candidate, validCreatedDate)
+                .orElseGet(() ->
+                        voteGroupToExpelRepository.save(
+                                VoteGroupToExpel.builder()
+                                        .project(project)
+                                        .candidate(candidate)
+                                        .build()
+                        )
+                );
+    }
+    
+    // 내보내기 투표 : 예외 처리 메서드
+    private boolean isSelfVote(Long voterId, Long candidateId) {
+        return Objects.equals(voterId, candidateId);
+    }
+
+    private boolean areNotEnoughProjectMembers(Project project) {
+        return project.getProjectMembers().size() <= 2;
+    }
+
+    private boolean isVoteGroupExpired(VoteGroup voteGroup) {
+        return voteGroup.getCreatedDate()
+                .isBefore(LocalDateTime.now().minusDays(VOTE_DURATION));
+    }
+
+    private boolean isVoteGroupAlreadyVoted(VoteGroup voteGroup, ProjectMember voter) {
+        return voteRepository.existsByVoteGroupAndVoter(voteGroup, voter);
+    }
+
+    // 공통 메서드
+    private ProjectMember findProjectMemberFrom(Project project, Long memberId) {
+        return project.getProjectMembers().stream()
+                .filter(projectMember -> Objects.equals(projectMember.getMember().getId(), memberId))
+                .findAny()
+                .orElseThrow(() ->  new ProjectMemberNotFoundException("memberId = " + memberId));
+    }
+
+    /* JPA 메서드 */
+    private Project findProject(Long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(() -> new ProjectNotFoundException("id = " + projectId));
+    }
+
+}

--- a/src/test/java/com/dnd/niceteam/vote/controller/VoteControllerTest.java
+++ b/src/test/java/com/dnd/niceteam/vote/controller/VoteControllerTest.java
@@ -1,0 +1,73 @@
+package com.dnd.niceteam.vote.controller;
+
+import com.dnd.niceteam.common.RestDocsConfig;
+import com.dnd.niceteam.review.MemberReviewTestFactory;
+import com.dnd.niceteam.review.dto.MemberReviewRequest;
+import com.dnd.niceteam.security.SecurityConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(RestDocsConfig.class)
+@AutoConfigureRestDocs
+@WebMvcTest(
+        controllers = VoteController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+        })
+class VoteControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser
+    @DisplayName("투표 표 등록")
+    void addMemberReview() throws Exception {
+        // given
+        MemberReviewRequest.Add request = MemberReviewTestFactory.getAddRequest();
+
+        // then
+        mockMvc.perform(
+                        post("/votes")
+                                .with(csrf())
+                                .accept(MediaType.APPLICATION_JSON)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                ).andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andDo(
+                        document("vote",
+                                requestFields(
+                                        fieldWithPath("type").description("투표 종류 (PROJECT_COMPLETE, EXPEL)"),
+                                        fieldWithPath("projectId").description("프로젝트 식별자"),
+                                        fieldWithPath("candidateMemberId").description("내보내기 투표 대상 멤버 식별자"),
+                                        fieldWithPath("choice").description("찬성, 반대 여부")
+                                )
+                        )
+                );
+    }
+
+}


### PR DESCRIPTION
# 구현 내용/방법

- 현재 develop 브랜치에 테스트가 깨져있어서 Service 테스트는 정상화된 후 진행할게요
- 내보내기 투표 시 발생하는 다양한 예외 및 정책을 적용했어요
  1. 팀원 수가 2명일 때 내보내기 투표 불가
  2. 자기 투표 불가
  3. 최초 투표 후 일주일이 지난 경우 투표 불가
  4. 이미 투표한 경우 중복 투표 불가
- 내보내기 투표를 한 지 일주일이 지난 후 투표할 경우, 새 내보내기 VoteGroup이 생성되도록 했어요

# 리뷰 필요

- 같은 팀원에 대해 다시 내보내기 투표를 열 경우를 위해 VoteGroupToExpel과 ProjectMember의 관계를 `@OnetoOne` 에서 `@ManyToOne`으로 변경했어요
- 추상 Super Class인 VoteGroup의 `checkComplete( )` 메서드를 템플릿 메서드 패턴으로 구현했어요💁‍♂️ 팀플 완료 투표는 만장일치 팀원 수가 실제 멤버수와 동일하고, 내보내기 투표는 나 자신을 빼고 만장일치라 이렇게 구현했는데 적절한가요?
- VoteService의 `voteToExpelCandidate( )` 메서드에 적용된 여러가지 예외처리를 보고 빠지거나 잘못된 코드는 없는지 한 번 봐주실 수 있나요?

close #80
