### PR TITLE
Feature/#13 푸쉬 알림 기능 추가 + 테스트 코드 픽스

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ out/
 
 ### 테스트 ###
 data.sql
+### Firebase ###
+springboot-fcm-test-firebase-adminsdk-o6qme-71dcb938bf.json

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 
     implementation 'io.awspring.cloud:spring-cloud-starter-aws-parameter-store-config'
 
+    // Firebase FCM
+    implementation 'com.google.firebase:firebase-admin:7.1.0'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 
     // Firebase FCM
     implementation 'com.google.firebase:firebase-admin:7.1.0'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/dnd/niceteam/NiceteamBackendApplication.java
+++ b/src/main/java/com/dnd/niceteam/NiceteamBackendApplication.java
@@ -2,8 +2,10 @@ package com.dnd.niceteam;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class NiceteamBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/dnd/niceteam/common/Domain.java
+++ b/src/main/java/com/dnd/niceteam/common/Domain.java
@@ -20,5 +20,7 @@ public enum Domain {
     APPLICANT,
 
     BOOKMARK,
+
+    NOTIFICATION,
     ;
 }

--- a/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
@@ -65,6 +65,9 @@ public enum ErrorCode {
     ALREADY_VOTED(VOTE, SC_BAD_REQUEST, "이미 투표에 참여하셨습니다."),
     NOT_ENOUGH_PROJECT_MEMBER(VOTE, SC_BAD_REQUEST, "투표를 하기 위해서는 팀원 수가 3명 이상이어야 합니다."),
     SELF_VOTE(VOTE, SC_BAD_REQUEST, "자기자신에게는 투표할 수 없습니다."),
+
+    // Firebase Notification
+    NOTIFICATION_PUSH_FAILED(NOTIFICATION, SC_INTERNAL_SERVER_ERROR, "푸쉬 알림 전송에 실패했습니다."),
     ;
 
     private final Domain domain;

--- a/src/main/java/com/dnd/niceteam/notification/config/FirebaseConfig.java
+++ b/src/main/java/com/dnd/niceteam/notification/config/FirebaseConfig.java
@@ -3,28 +3,24 @@ package com.dnd.niceteam.notification.config;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
 
 import javax.annotation.PostConstruct;
 
 @Configuration
 @Slf4j
+@RequiredArgsConstructor
 public class FirebaseConfig {
 
-    private final String configPath;
-
-    public FirebaseConfig(@Value("${firebase.config-path}") String configPath) {
-        this.configPath = configPath;
-    }
+    private final FirebaseProperties firebaseProperties;
 
     @PostConstruct
     public void init() {
         try {
             FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(GoogleCredentials.fromStream(new ClassPathResource(configPath).getInputStream()))
+                    .setCredentials(GoogleCredentials.fromStream(firebaseProperties.toStream()))
                     .build();
 
             if (FirebaseApp.getApps().isEmpty()) {

--- a/src/main/java/com/dnd/niceteam/notification/config/FirebaseConfig.java
+++ b/src/main/java/com/dnd/niceteam/notification/config/FirebaseConfig.java
@@ -1,0 +1,41 @@
+package com.dnd.niceteam.notification.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import javax.annotation.PostConstruct;
+
+@Configuration
+@Slf4j
+public class FirebaseConfig {
+
+    private final String configPath;
+
+    public FirebaseConfig(@Value("${firebase.config-path}") String configPath) {
+        this.configPath = configPath;
+    }
+
+    @PostConstruct
+    public void init() {
+        try {
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(new ClassPathResource(configPath).getInputStream()))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+                log.info("FirebaseApp has been initialized");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}
+
+

--- a/src/main/java/com/dnd/niceteam/notification/config/FirebaseProperties.java
+++ b/src/main/java/com/dnd/niceteam/notification/config/FirebaseProperties.java
@@ -1,0 +1,43 @@
+package com.dnd.niceteam.notification.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.Serializable;
+
+@Getter
+@RequiredArgsConstructor
+@ConstructorBinding
+@ConfigurationProperties("firebase")
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class FirebaseProperties implements Serializable {
+
+    private final String type;
+    private final String projectId;
+
+    private final String privateKeyId;
+    private final String privateKey;
+
+    private final String clientEmail;
+    private final String clientId;
+
+    private final String authUri;
+    private final String tokenUri;
+
+    private final String authProviderX509CertUrl;
+    private final String clientX509CertUrl;
+
+    public InputStream toStream() throws JsonProcessingException {
+        String serializedProperties = new ObjectMapper().writeValueAsString(this).replaceAll("\\\\n", "\\n");
+        return new ByteArrayInputStream(serializedProperties.getBytes());
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/notification/config/NotificationParams.java
+++ b/src/main/java/com/dnd/niceteam/notification/config/NotificationParams.java
@@ -1,0 +1,15 @@
+package com.dnd.niceteam.notification.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationParams {
+    SOUND("default")
+    , COLOR("#FFFF00")
+    ;
+
+    private final String value;
+
+}

--- a/src/main/java/com/dnd/niceteam/notification/controller/NotificationController.java
+++ b/src/main/java/com/dnd/niceteam/notification/controller/NotificationController.java
@@ -1,0 +1,35 @@
+package com.dnd.niceteam.notification.controller;
+
+import com.dnd.niceteam.notification.dto.NotificationRequestDto;
+import com.dnd.niceteam.notification.dto.NotificationResponseDto;
+import com.dnd.niceteam.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/notifications")
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @PostMapping
+    public ResponseEntity<NotificationResponseDto> send(@RequestBody NotificationRequestDto request) {
+        try {
+            notificationService.send(request);
+            log.info("Send notification successfully");
+            return ResponseEntity.ok(new NotificationResponseDto("푸쉬 알림이 전송되었습니다."));
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/notification/controller/NotificationController.java
+++ b/src/main/java/com/dnd/niceteam/notification/controller/NotificationController.java
@@ -1,11 +1,12 @@
 package com.dnd.niceteam.notification.controller;
 
+import com.dnd.niceteam.common.dto.ApiResult;
 import com.dnd.niceteam.notification.dto.NotificationRequestDto;
 import com.dnd.niceteam.notification.dto.NotificationResponseDto;
+import com.dnd.niceteam.notification.exception.NotificationPushFailedException;
 import com.dnd.niceteam.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,14 +22,15 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @PostMapping
-    public ResponseEntity<NotificationResponseDto> send(@RequestBody NotificationRequestDto request) {
+    public ResponseEntity<ApiResult<NotificationResponseDto>> send(@RequestBody NotificationRequestDto request) {
         try {
             notificationService.send(request);
             log.info("Send notification successfully");
-            return ResponseEntity.ok(new NotificationResponseDto("푸쉬 알림이 전송되었습니다."));
+            ApiResult<NotificationResponseDto> apiResult = ApiResult.success(new NotificationResponseDto("푸쉬 알림이 전송되었습니다."));
+            return ResponseEntity.ok(apiResult);
         } catch (Exception e) {
             System.out.println(e.getMessage());
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+            throw new NotificationPushFailedException(request.getTitle(), request.getMessage());
         }
     }
 

--- a/src/main/java/com/dnd/niceteam/notification/dto/NotificationRequestDto.java
+++ b/src/main/java/com/dnd/niceteam/notification/dto/NotificationRequestDto.java
@@ -1,0 +1,20 @@
+package com.dnd.niceteam.notification.dto;
+
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+public class NotificationRequestDto {
+
+    private String title;
+
+    private String message;
+
+    private String topic;
+
+    private String token;
+
+    private Map<String, String> data;
+
+}

--- a/src/main/java/com/dnd/niceteam/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/dnd/niceteam/notification/dto/NotificationResponseDto.java
@@ -1,0 +1,14 @@
+package com.dnd.niceteam.notification.dto;
+
+import lombok.Data;
+
+@Data
+public class NotificationResponseDto {
+
+    private String message;
+
+    public NotificationResponseDto(String message) {
+        this.message = message;
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/notification/exception/NotificationPushFailedException.java
+++ b/src/main/java/com/dnd/niceteam/notification/exception/NotificationPushFailedException.java
@@ -1,0 +1,11 @@
+package com.dnd.niceteam.notification.exception;
+
+import com.dnd.niceteam.error.exception.BusinessException;
+import com.dnd.niceteam.error.exception.ErrorCode;
+
+public class NotificationPushFailedException extends BusinessException {
+
+    public NotificationPushFailedException(String title, String message) {
+        super(ErrorCode.NOTIFICATION_PUSH_FAILED, String.format("title = %s, message = %s", title, message));
+    }
+}

--- a/src/main/java/com/dnd/niceteam/notification/service/FirebaseCloudMessagingService.java
+++ b/src/main/java/com/dnd/niceteam/notification/service/FirebaseCloudMessagingService.java
@@ -1,0 +1,21 @@
+package com.dnd.niceteam.notification.service;
+
+import com.dnd.niceteam.notification.dto.NotificationRequestDto;
+import com.dnd.niceteam.notification.util.FCMUtil;
+import com.google.firebase.messaging.Message;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ExecutionException;
+
+@Service
+@Slf4j
+public class FirebaseCloudMessagingService {
+
+    public String sendMessageToToken(NotificationRequestDto request)
+            throws InterruptedException, ExecutionException {
+        Message message = FCMUtil.buildMessage(request);
+        return FCMUtil.sendToFirebase(message);
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/notification/service/FirebaseCloudMessagingService.java
+++ b/src/main/java/com/dnd/niceteam/notification/service/FirebaseCloudMessagingService.java
@@ -1,6 +1,5 @@
 package com.dnd.niceteam.notification.service;
 
-import com.dnd.niceteam.notification.dto.NotificationRequestDto;
 import com.dnd.niceteam.notification.util.FCMUtil;
 import com.google.firebase.messaging.Message;
 import lombok.extern.slf4j.Slf4j;
@@ -12,9 +11,8 @@ import java.util.concurrent.ExecutionException;
 @Slf4j
 public class FirebaseCloudMessagingService {
 
-    public String sendMessageToToken(NotificationRequestDto request)
+    public String sendMessageToToken(Message message)
             throws InterruptedException, ExecutionException {
-        Message message = FCMUtil.buildMessage(request);
         return FCMUtil.sendToFirebase(message);
     }
 

--- a/src/main/java/com/dnd/niceteam/notification/service/FirebaseCloudMessagingService.java
+++ b/src/main/java/com/dnd/niceteam/notification/service/FirebaseCloudMessagingService.java
@@ -11,7 +11,7 @@ import java.util.concurrent.ExecutionException;
 @Slf4j
 public class FirebaseCloudMessagingService {
 
-    public String sendMessageToToken(Message message)
+    public String sendMessage(Message message)
             throws InterruptedException, ExecutionException {
         return FCMUtil.sendToFirebase(message);
     }

--- a/src/main/java/com/dnd/niceteam/notification/service/NotificationService.java
+++ b/src/main/java/com/dnd/niceteam/notification/service/NotificationService.java
@@ -1,0 +1,25 @@
+package com.dnd.niceteam.notification.service;
+
+import com.dnd.niceteam.notification.dto.NotificationRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ExecutionException;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final FirebaseCloudMessagingService fcmService;
+
+    public void send(NotificationRequestDto request) {
+        try {
+            fcmService.sendMessageToToken(request);
+        } catch (InterruptedException | ExecutionException e) {
+            log.error(e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/dnd/niceteam/notification/service/NotificationService.java
+++ b/src/main/java/com/dnd/niceteam/notification/service/NotificationService.java
@@ -20,7 +20,7 @@ public class NotificationService {
 
     public void send(NotificationRequestDto request) throws ExecutionException, InterruptedException {
             Message message = FCMUtil.buildMessage(request);
-            fcmService.sendMessageToToken(message);
+            fcmService.sendMessage(message);
     }
 
 }

--- a/src/main/java/com/dnd/niceteam/notification/service/NotificationService.java
+++ b/src/main/java/com/dnd/niceteam/notification/service/NotificationService.java
@@ -1,6 +1,9 @@
 package com.dnd.niceteam.notification.service;
 
 import com.dnd.niceteam.notification.dto.NotificationRequestDto;
+import com.dnd.niceteam.notification.util.FCMUtil;
+import com.google.firebase.messaging.Message;
+import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -10,16 +13,14 @@ import java.util.concurrent.ExecutionException;
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class NotificationService {
 
     private final FirebaseCloudMessagingService fcmService;
 
-    public void send(NotificationRequestDto request) {
-        try {
-            fcmService.sendMessageToToken(request);
-        } catch (InterruptedException | ExecutionException e) {
-            log.error(e.getMessage());
-        }
+    public void send(NotificationRequestDto request) throws ExecutionException, InterruptedException {
+            Message message = FCMUtil.buildMessage(request);
+            fcmService.sendMessageToToken(message);
     }
 
 }

--- a/src/main/java/com/dnd/niceteam/notification/util/FCMUtil.java
+++ b/src/main/java/com/dnd/niceteam/notification/util/FCMUtil.java
@@ -5,6 +5,7 @@ import com.dnd.niceteam.notification.dto.NotificationRequestDto;
 import com.google.firebase.messaging.*;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 public final class FCMUtil {
@@ -24,7 +25,8 @@ public final class FCMUtil {
 
         Message.Builder messageBuilder = Message.builder();
 
-        if (!request.getData().isEmpty()) messageBuilder.putAllData(request.getData());
+        Map<String, String> messageData = request.getData();
+        if (messageData != null) messageBuilder.putAllData(messageData);
 
         // 토큰이 있으면 토큰을, 없으면 Topic을 주입
         if (request.getToken() != null) messageBuilder.setToken(request.getToken());

--- a/src/main/java/com/dnd/niceteam/notification/util/FCMUtil.java
+++ b/src/main/java/com/dnd/niceteam/notification/util/FCMUtil.java
@@ -1,0 +1,62 @@
+package com.dnd.niceteam.notification.util;
+
+import com.dnd.niceteam.notification.config.NotificationParams;
+import com.dnd.niceteam.notification.dto.NotificationRequestDto;
+import com.google.firebase.messaging.*;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+
+public final class FCMUtil {
+
+    private FCMUtil() {}
+
+    public static Notification buildNotification(NotificationRequestDto request) {
+        return Notification.builder()
+                .setTitle(request.getTitle())
+                .setBody(request.getMessage())
+                .build();
+    }
+
+    public static Message buildMessage(NotificationRequestDto request) {
+        Notification notification = buildNotification(request);
+        AndroidConfig androidConfig = getAndroidConfig(request.getTopic());
+
+        Message.Builder messageBuilder = Message.builder();
+
+        if (!request.getData().isEmpty()) messageBuilder.putAllData(request.getData());
+
+        // 토큰이 있으면 토큰을, 없으면 Topic을 주입
+        if (request.getToken() != null) messageBuilder.setToken(request.getToken());
+        else messageBuilder.setTopic(request.getTopic());
+
+        return messageBuilder
+                .setNotification(notification)
+                .setAndroidConfig(androidConfig)
+                .build();
+    }
+
+    public static String sendToFirebase(Message message) throws InterruptedException, ExecutionException {
+        return FirebaseMessaging.getInstance().sendAsync(message).get();
+    }
+
+    /* Android 관련 메서드 */
+    private static AndroidConfig getAndroidConfig(String topic) {
+        AndroidNotification notification = getAndroidNotification(topic);
+
+        return AndroidConfig.builder()
+                .setTtl(Duration.ofMinutes(2).toMillis()).setCollapseKey(topic)
+                .setPriority(AndroidConfig.Priority.HIGH)
+                .setNotification(notification)
+                .build();
+    }
+
+    private static AndroidNotification getAndroidNotification(String topic) {
+        return AndroidNotification.builder()
+                .setSound(NotificationParams.SOUND.getValue())
+                .setColor(NotificationParams.COLOR.getValue())
+                .setTag(topic)
+                .build();
+    }
+
+}

--- a/src/main/resources/application-firebase.yml
+++ b/src/main/resources/application-firebase.yml
@@ -1,0 +1,29 @@
+firebase:
+  type: ${firebase.type}
+  project-id: ${firebase.project_id}
+  private-key-id: ${firebase.private_key_id}
+  private-key: ${firebase.private_key}
+  client-email: ${firebase.client_email}
+  client-id: ${firebase.client_id}
+  auth-uri: ${firebase.auth_uri}
+  token-uri: ${firebase.token_uri}
+  auth-provider-x509-cert-url: ${firebase.auth_provider_x509_cert_url}
+  client-x509-cert-url: ${firebase.client_x509_cert_url}
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+
+firebase:
+  type: undefined
+  project-id: undefined
+  private-key-id: undefined
+  private-key: undefined
+  client-email: undefined
+  client-id: undefined
+  auth-uri: undefined
+  token-uri: undefined
+  auth-provider-x509-cert-url: undefined
+  client-x509-cert-url: undefined

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,17 +4,14 @@ spring:
   profiles:
     active: local
     group:
-      local: db, jwt, mail
-      dev: db, jwt, mail
+      local: db, firebase, jwt, mail
+      dev: db, firebase, jwt, mail
 aws:
   paramstore:
     name: niceteam
     enabled: true
     prefix: /config
     profile-separator: _
-
-firebase:
-  config-path: firebase/springboot-fcm-test-firebase-adminsdk-o6qme-71dcb938bf.json
 ---
 spring:
   config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,8 @@ aws:
     prefix: /config
     profile-separator: _
 
+firebase:
+  config-path: firebase/springboot-fcm-test-firebase-adminsdk-o6qme-71dcb938bf.json
 ---
 spring:
   config:

--- a/src/test/java/com/dnd/niceteam/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/notification/service/NotificationServiceTest.java
@@ -24,11 +24,29 @@ class NotificationServiceTest {
     FirebaseCloudMessagingService fcmService;
 
     @Test
-    void 푸쉬_알람_전송() throws ExecutionException, InterruptedException {
+    void sendPushNotificationWithToken() throws ExecutionException, InterruptedException {
         // given
         NotificationRequestDto request = new NotificationRequestDto();
         request.setTitle("팀원 수락");
         request.setMessage("DND 7기 2조에 합류하신걸 축하합니다!");
+        request.setToken("테스트용 토큰");
+
+        when(fcmService.sendMessage(any(Message.class))).thenReturn("푸쉬 알람 전송 성공");
+
+        // when
+        notificationService.send(request);
+
+        // then
+        verify(fcmService).sendMessage(any(Message.class));
+    }
+
+    @Test
+    void sendPushNotificationWithTopic() throws ExecutionException, InterruptedException {
+        // given
+        NotificationRequestDto request = new NotificationRequestDto();
+        request.setTitle("팀원 수락");
+        request.setMessage("DND 7기 2조에 합류하신걸 축하합니다!");
+        request.setTopic("test-topic");
 
         when(fcmService.sendMessage(any(Message.class))).thenReturn("푸쉬 알람 전송 성공");
 

--- a/src/test/java/com/dnd/niceteam/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/notification/service/NotificationServiceTest.java
@@ -1,6 +1,7 @@
 package com.dnd.niceteam.notification.service;
 
 import com.dnd.niceteam.notification.dto.NotificationRequestDto;
+import com.google.firebase.messaging.Message;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -9,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.concurrent.ExecutionException;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,13 +30,13 @@ class NotificationServiceTest {
         request.setTitle("팀원 수락");
         request.setMessage("DND 7기 2조에 합류하신걸 축하합니다!");
 
-        when(fcmService.sendMessageToToken(request)).thenReturn("푸쉬 알람 전송 성공");
+        when(fcmService.sendMessage(any(Message.class))).thenReturn("푸쉬 알람 전송 성공");
 
         // when
         notificationService.send(request);
 
         // then
-        verify(fcmService).sendMessageToToken(request);
+        verify(fcmService).sendMessage(any(Message.class));
     }
 
 

--- a/src/test/java/com/dnd/niceteam/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/notification/service/NotificationServiceTest.java
@@ -1,0 +1,41 @@
+package com.dnd.niceteam.notification.service;
+
+import com.dnd.niceteam.notification.dto.NotificationRequestDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @InjectMocks
+    NotificationService notificationService;
+
+    @Mock
+    FirebaseCloudMessagingService fcmService;
+
+    @Test
+    void 푸쉬_알람_전송() throws ExecutionException, InterruptedException {
+        // given
+        NotificationRequestDto request = new NotificationRequestDto();
+        request.setTitle("팀원 수락");
+        request.setMessage("DND 7기 2조에 합류하신걸 축하합니다!");
+
+        when(fcmService.sendMessageToToken(request)).thenReturn("푸쉬 알람 전송 성공");
+
+        // when
+        notificationService.send(request);
+
+        // then
+        verify(fcmService).sendMessageToToken(request);
+    }
+
+
+}

--- a/src/test/java/com/dnd/niceteam/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/project/service/ProjectServiceTest.java
@@ -164,7 +164,7 @@ class ProjectServiceTest {
         when(recruitingRepository.findById(anyLong())).thenReturn(Optional.of(recruiting));
         when(recruiting.getProject()).thenReturn(project);
         when(project.getId()).thenReturn(1L);
-        when(recruiting.isRecruiter(any())).thenReturn(true);
+        when(recruiting.checkRecruiter(any())).thenReturn(true);
 
         Applicant applicant = mock(Applicant.class);
         when(applicantRepository.findByMemberIdAndRecruitingId(anyLong(), anyLong())).thenReturn(Optional.of(applicant));

--- a/src/test/java/com/dnd/niceteam/vote/VoteTestFactory.java
+++ b/src/test/java/com/dnd/niceteam/vote/VoteTestFactory.java
@@ -5,6 +5,7 @@ import com.dnd.niceteam.domain.code.FieldCategory;
 import com.dnd.niceteam.domain.code.VoteType;
 import com.dnd.niceteam.domain.member.Member;
 import com.dnd.niceteam.domain.project.Project;
+import com.dnd.niceteam.domain.project.ProjectMember;
 import com.dnd.niceteam.domain.project.SideProject;
 import com.dnd.niceteam.vote.dto.VoteRequest;
 import org.springframework.security.core.authority.AuthorityUtils;
@@ -47,8 +48,8 @@ public class VoteTestFactory {
                 .fieldCategory(FieldCategory.CLUB)
                 .build();
 
-        project.addMember(currentMember);
-        project.addMember(teamMember);
+        project.addMember(ProjectMember.builder().project(project).member(currentMember).build());
+        project.addMember(ProjectMember.builder().project(project).member(currentMember).build());
 
         return project;
     }


### PR DESCRIPTION
# 구현 내용/방법

- FCM 푸쉬 알림을 손쉽게 이용할 수 있는 API를 추가했어요!
- Firebase 계정 credential 정보를 환경변수로 받아오도록 설정했어요
   (배포 시 application-firebase.yml을 참고해서 env 설정하시면 돼요😊)
   
- 푸쉬 알림의 title, message를 token 또는 topic을 통한 전파 방식 중 하나를 선택해 보낼 수 있어요

close #13
