### PR TITLE
Feature/#99 Recruiting 모집글 검색 목록 조회

### DIFF
--- a/src/docs/asciidoc/recruiting.adoc
+++ b/src/docs/asciidoc/recruiting.adoc
@@ -29,3 +29,8 @@ operation::my-recruiting-list[snippets='http-request,request-parameters,http-res
 == 사이드 모집글 추천 목록 조회
 
 operation::recruiting-recommend-side[snippets='http-request,request-parameters,http-response,response-fields-data']
+
+[[recruiting-search-list]]
+== 모집글 검색 목록 조회
+
+operation::recruiting-search-list[snippets='http-request,request-parameters,http-response,response-fields-data']

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/Recruiting.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/Recruiting.java
@@ -71,8 +71,9 @@ public class Recruiting extends BaseEntity {
     @Column(name = "pool_up_date")
     private LocalDateTime poolUpDate;
 
+    @Builder.Default
     @Column(name = "intro_link", nullable = false)
-    private String introLink;
+    private String introLink = "";
 
     @Builder.Default
     @ElementCollection(fetch = FetchType.LAZY)

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/RecruitingRepositoryCustom.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/RecruitingRepositoryCustom.java
@@ -8,4 +8,9 @@ import java.util.Set;
 
 public interface RecruitingRepositoryCustom {
     Page<Recruiting> findAllByInterestingFieldsOrderByWriterLevel(Set<Field> interestingFields, Pageable pageable);
+
+    Page<Recruiting> findAllSideBySearchWordAndFieldOrderByCreatedDate(String searchWord, Field field, Pageable pageable);
+
+    Page<Recruiting> findAllLectureBySearchWordAndDepartmentOrderByCreatedDate(String searchWord, String department, Pageable pageable);
+
 }

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/RecruitingRepositoryCustomImpl.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/RecruitingRepositoryCustomImpl.java
@@ -1,15 +1,20 @@
 package com.dnd.niceteam.domain.recruiting;
 
 import com.dnd.niceteam.domain.code.Field;
-import com.dnd.niceteam.domain.code.ProgressStatus;
+import com.dnd.niceteam.domain.code.Type;
+import com.dnd.niceteam.domain.project.Project;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Set;
 
+import static com.dnd.niceteam.domain.project.QLectureProject.lectureProject;
 import static com.dnd.niceteam.domain.project.QProject.project;
 import static com.dnd.niceteam.domain.project.QSideProject.sideProject;
 import static com.dnd.niceteam.domain.recruiting.QRecruiting.recruiting;
@@ -48,5 +53,104 @@ public class RecruitingRepositoryCustomImpl implements RecruitingRepositoryCusto
                 .fetchOne();
 
         return new PageImpl<>(recruitings, pageable, totalCount);
+    }
+    // SIDE
+    // 검색어 o -> 해당 단어를 포함하는 프로젝트명과 모집글 제목 필터링
+    // 분야 o -> 분야 필터링
+    @Override
+    public Page<Recruiting> findAllSideBySearchWordAndFieldOrderByCreatedDate(String searchWord, Field field, Pageable pageable) {
+        List<Recruiting> recruitings = query
+                .select(recruiting)
+                .from(recruiting)
+                .join(recruiting.project, project)
+                .where(project
+                        .in(findSideProjectsBySearchWordAndField(searchWord, field))
+                        .and(project.type.eq(Type.SIDE))
+                        .or(nameContains(recruiting.title, searchWord))
+                )
+                .orderBy(recruiting.createdDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long totalCount = query
+                .select(recruiting.count())
+                .from(recruiting)
+                .join(recruiting.project, project)
+                .where(project
+                        .in(findSideProjectsBySearchWordAndField(searchWord, field))
+                        .and(project.type.eq(Type.SIDE))
+                        .or(nameContains(recruiting.title, searchWord)) //프로젝트 내에서는 searchWord랑 필드가 같은 데이터 혹은 리크루팅 내에서는 리크루팅 제목에 포함되는 데이터
+                )
+                .fetchOne();
+        return new PageImpl<>(recruitings, pageable, totalCount);
+    }
+
+    // LECTURE
+    // 검색어 x -> 회원 전공 필터링
+    // 검색어 o -> 해당 단어를 포함하는 강의명 or 교수명 or 전공명 or 모집글 제목 필터링 & 회원 전공 필터링 X
+    @Override
+    public Page<Recruiting> findAllLectureBySearchWordAndDepartmentOrderByCreatedDate (String searchWord, String memberDepartment, Pageable pageable) {
+        List<Recruiting> recruitings = query
+                .select(recruiting)
+                .from(recruiting)
+                .join(recruiting.project, project)
+                .where(project
+                        .in(findLectureProjectsBySearchWordAndDepartment(searchWord, memberDepartment))
+                        .and(project.type.eq(Type.LECTURE))
+                        .or(nameContains(recruiting.title, searchWord))
+                )
+                .orderBy(recruiting.createdDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long totalCount = query
+                .select(recruiting.count())
+                .from(recruiting)
+                .join(recruiting.project, project)
+                .where(project
+                        .in(findLectureProjectsBySearchWordAndDepartment(searchWord, memberDepartment))
+                        .and(project.type.eq(Type.LECTURE))
+                        .or(nameContains(recruiting.title, searchWord))
+                )
+                .fetchOne();
+
+        return new PageImpl<>(recruitings, pageable, totalCount);
+    }
+
+    private List<Project> findLectureProjectsBySearchWordAndDepartment(String searchWord, String department) {
+        return query.selectFrom(project)
+                .leftJoin(lectureProject).on(lectureProject.eq(project))
+                .where(nameContains(lectureProject.name, searchWord)
+                        .or(nameContains(lectureProject.professor, searchWord))
+                        .or(nameContains(lectureProject.name, searchWord))
+                        .or(nameContains(lectureProject.department.name, searchWord))
+                        .and(departmentEqWhenSearchWordisNull(lectureProject.department.name, department, searchWord))
+                )
+                .fetch();
+    }
+
+    private List<Project> findSideProjectsBySearchWordAndField(String searchWord, Field field) {
+        return query.selectFrom(project)
+                .leftJoin(sideProject).on(sideProject.eq(project))
+                .where(
+                        nameContains(sideProject.name, searchWord)
+                                .and(fieldEq(field))    // searchWord가 null이면 무시하고, 필드가 같아야 한다.)
+                )
+                .fetch();
+    }
+
+
+    private BooleanBuilder departmentEqWhenSearchWordisNull(StringPath name, String memberDepartment, String searchWord) {
+        return searchWord == null ? new BooleanBuilder(name.eq(memberDepartment)) : new BooleanBuilder();
+    }
+
+    private BooleanBuilder nameContains(StringPath name, String searchWord) {
+        return searchWord != null ? new BooleanBuilder(name.contains(searchWord)) : new BooleanBuilder();
+    }
+
+    private BooleanBuilder fieldEq(Field filteredField) {
+        return filteredField != null ? new BooleanBuilder(sideProject.field.eq(filteredField)) : new BooleanBuilder();
     }
 }

--- a/src/main/java/com/dnd/niceteam/recruiting/controller/RecruitingController.java
+++ b/src/main/java/com/dnd/niceteam/recruiting/controller/RecruitingController.java
@@ -2,7 +2,9 @@ package com.dnd.niceteam.recruiting.controller;
 
 import com.dnd.niceteam.common.dto.ApiResult;
 import com.dnd.niceteam.common.dto.Pagination;
+import com.dnd.niceteam.domain.code.Field;
 import com.dnd.niceteam.domain.code.ProgressStatus;
+import com.dnd.niceteam.domain.code.Type;
 import com.dnd.niceteam.recruiting.dto.RecruitingCreation;
 import com.dnd.niceteam.recruiting.dto.RecruitingFind;
 import com.dnd.niceteam.recruiting.service.RecruitingService;
@@ -63,6 +65,21 @@ public class RecruitingController {
 
         Pagination<RecruitingFind.RecommendedListResponseDto> recruitings = recruitingService.getRecommendedRecruitings(page, perSize, username);
         ApiResult<Pagination<RecruitingFind.RecommendedListResponseDto>> apiResult = ApiResult.success(recruitings);
+        return ResponseEntity.ok(apiResult);
+    }
+
+    // 키워드 검색 & 목록 조회(필터링)
+    @GetMapping
+    public ResponseEntity<ApiResult<Pagination<RecruitingFind.ListResponseDto>>> searchRecruitingList(
+            @RequestParam(defaultValue = "1", required = false) Integer page,
+            @RequestParam(defaultValue = "10", required = false) Integer perSize,
+            @RequestParam(required = false) Field field,        // only used at SIDE
+            @RequestParam Type type,
+            @RequestParam(required = false) String searchWord,
+            @CurrentUsername String username) {
+        Pagination<RecruitingFind.ListResponseDto> recruitings = recruitingService.getSearchRecruitings(page, perSize, field, type, searchWord, username);
+
+        ApiResult<Pagination<RecruitingFind.ListResponseDto>> apiResult = ApiResult.success(recruitings);
         return ResponseEntity.ok(apiResult);
     }
 }

--- a/src/main/java/com/dnd/niceteam/recruiting/dto/RecruitingCreation.java
+++ b/src/main/java/com/dnd/niceteam/recruiting/dto/RecruitingCreation.java
@@ -28,7 +28,7 @@ public interface RecruitingCreation {
         private Type recruitingType;
         @NotNull
         private ActivityArea activityArea;
-        @Nullable
+        @NotNull
         private String introLink;
         @NotNull
         private ProgressStatus status;

--- a/src/main/java/com/dnd/niceteam/recruiting/dto/RecruitingFind.java
+++ b/src/main/java/com/dnd/niceteam/recruiting/dto/RecruitingFind.java
@@ -8,6 +8,7 @@ import com.dnd.niceteam.domain.recruiting.Recruiting;
 import com.dnd.niceteam.domain.recruiting.exception.InvalidRecruitingTypeException;
 import com.dnd.niceteam.project.dto.ProjectResponse;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 
 import javax.validation.constraints.NotNull;
@@ -78,6 +79,7 @@ public interface RecruitingFind {
     }
 
     @Data
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     class ListResponseDto {
         // 목록 조회
         @NotNull private Long id;
@@ -95,10 +97,25 @@ public interface RecruitingFind {
         // 내가 쓴글 조회
         private LocalDateTime createdDate;
 
+        // 검색 목록 조회
+        private LocalDate recruitingEndDate;
+        private Integer recruitingMemberCount;
+        private String recruiterNickname;
+
         public static ListResponseDto fromMyList(Recruiting recruiting) {
             ListResponseDto dto = createCommonListResponseDto(recruiting);
 
             dto.setCreatedDate(recruiting.getCreatedDate());
+            return dto;
+        }
+
+        public static ListResponseDto fromSearchList(Recruiting recruiting) {
+            ListResponseDto dto = createCommonListResponseDto(recruiting);
+
+            dto.setRecruitingEndDate(recruiting.getRecruitingEndDate());
+            dto.setRecruitingMemberCount(recruiting.getRecruitingMemberCount());
+            dto.setRecruiterNickname(recruiting.getMember().getNickname());
+
             return dto;
         }
 

--- a/src/test/java/com/dnd/niceteam/comment/DtoFactoryForTest.java
+++ b/src/test/java/com/dnd/niceteam/comment/DtoFactoryForTest.java
@@ -9,6 +9,7 @@ import com.dnd.niceteam.recruiting.dto.RecruitingCreation;
 import com.dnd.niceteam.recruiting.dto.RecruitingFind;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Set;
@@ -110,6 +111,7 @@ public class DtoFactoryForTest {
         dto.setStatus(ProgressStatus.IN_PROGRESS);
         dto.setCommentCount(0);
         dto.setBookmarkCount(0);
+        dto.setCreatedDate(LocalDateTime.of(2022,8,21,13,0));
         dto.setProjectName("test-lecture-project-name");
         dto.setProfessor("test-professor-name");
         return dto;
@@ -136,5 +138,22 @@ public class DtoFactoryForTest {
         dto.setEndTime(LocalTime.of(20, 30));
 
         return Set.of(dto);
+    }
+
+    public static RecruitingFind.ListResponseDto createSearchSideListResponseDto() {
+        RecruitingFind.ListResponseDto responseDto = new RecruitingFind.ListResponseDto();
+        responseDto.setId(1L);
+        responseDto.setRecruiterNickname("writer-tester");
+        responseDto.setRecruitingMemberCount(4);
+        responseDto.setRecruitingEndDate(LocalDate.of(2022,8,28));
+        responseDto.setStatus(ProgressStatus.IN_PROGRESS);
+        responseDto.setTitle("모집글 제목 테스트");
+        responseDto.setProjectName("프르젝트명 테스트");
+        responseDto.setBookmarkCount(2);
+        responseDto.setCommentCount(2);
+        responseDto.setType(Type.SIDE);
+        responseDto.setField(Field.IT_SW_GAME);
+        responseDto.setFieldCategory(FieldCategory.STUDY);
+        return responseDto;
     }
 }

--- a/src/test/java/com/dnd/niceteam/recruiting/service/RecruitingServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/recruiting/service/RecruitingServiceTest.java
@@ -189,4 +189,114 @@ class RecruitingServiceTest {
         assertThat(recommendedRecruitings.getContents().get(0).getRecruitingId()).isEqualTo(savedRecommendedRecruiting.getId());
         assertThat(recommendedRecruitings.getContents().size()).isEqualTo(1);
     }
+
+    @DisplayName("모집글 키워드 검색 서비스 테스트 코드")
+    @Test
+    public void getSearchRecruitingWithKeywordPage() {
+        // given
+        String projectName = "DND 동아리원 구해요!";
+        Project savedLectureProject = projectRepository.save(createLectureProject(department));
+        Project savedSideProject = projectRepository.save(SideProject.builder()
+                .name(projectName)
+                .field(Field.DESIGN)
+                .fieldCategory(FieldCategory.STUDY)
+                .startDate(LocalDate.of(2022, 7, 4))
+                .endDate(LocalDate.of(2022, 8, 30))
+                .build()
+        );
+        recruitingRepository.save(createRecruiting(member, savedLectureProject, Type.LECTURE));
+        recruitingRepository.save(createRecruiting(member, savedSideProject, Type.SIDE));
+
+        // when (SIDE탭에서 키워드 검색)
+        Pagination<RecruitingFind.ListResponseDto> searchRecruitingPage = recruitingService.getSearchRecruitings(page, perSize, null, Type.SIDE, "DND", account.getEmail());
+        Pagination<RecruitingFind.ListResponseDto> nonSearchRecruitingPage = recruitingService.getSearchRecruitings(page, perSize, null, Type.SIDE, "DND동아리원", account.getEmail());
+
+        // then
+        Page<Recruiting> foundRecommendedRecruitingsPage = recruitingRepository.findAllSideBySearchWordAndFieldOrderByCreatedDate("DND", null, pageable);
+        // 검색 o
+        assertThat(searchRecruitingPage.getTotalCount()).isEqualTo(foundRecommendedRecruitingsPage.getTotalElements());
+        assertThat(searchRecruitingPage.getPage()).isEqualTo(0);
+        assertThat(searchRecruitingPage.getTotalPages()).isEqualTo(1);
+        assertThat(searchRecruitingPage.getContents().get(0).getProjectName()).isEqualTo(projectName);
+        assertThat(searchRecruitingPage.getContents().size()).isEqualTo(1);
+        // 검색 x
+        assertThat(nonSearchRecruitingPage.getTotalCount()).isEqualTo(0);
+        assertThat(nonSearchRecruitingPage.getContents().size()).isEqualTo(0);
+    }
+
+
+    @DisplayName("사이드 모집글 검색 목록 조회 서비스 테스트 코드")
+    @Test
+    public void getSearchRecruitingPage() {
+        // given
+        String projectName = "나중에 등록된 프로젝트!";
+        Project lectureProjectWithSameDeaprtment = projectRepository.save(createLectureProject(department));
+        Project lectureProjectWithNonsameDepartment = projectRepository.save(createLectureProject(departmentRepository.save(Department.builder()
+                .university(university)
+                .collegeName("학교")
+                .region("부산")
+                .mainBranchType("main")
+                .name("다른 학과")
+                .build())));
+
+        Project savedSideProject = projectRepository.save(createSideProject());
+        Project afterSavedSideProject = projectRepository.save(SideProject.builder()
+                .name(projectName)
+                .field(Field.DESIGN)
+                .fieldCategory(FieldCategory.STUDY)
+                .startDate(LocalDate.of(2022, 7, 4))
+                .endDate(LocalDate.of(2022, 8, 30))
+                .build()
+        );
+        recruitingRepository.save(createRecruiting(member, lectureProjectWithNonsameDepartment, Type.LECTURE));
+        recruitingRepository.save(createRecruiting(member, lectureProjectWithSameDeaprtment, Type.LECTURE));
+        recruitingRepository.save(createRecruiting(member, savedSideProject, Type.SIDE));
+        recruitingRepository.save(createRecruiting(member, afterSavedSideProject, Type.SIDE));
+
+        // when
+        Pagination<RecruitingFind.ListResponseDto> allSideRecruitingsPage = recruitingService.getSearchRecruitings(page, perSize, null, Type.SIDE, null, account.getEmail());   // side - 전체 조회
+        Pagination<RecruitingFind.ListResponseDto> allSideRecruitingsPageWithFiltered = recruitingService.getSearchRecruitings(page, perSize, Field.DESIGN, Type.SIDE, null, account.getEmail());   // side - 분야 필터링 조회
+
+        // then
+        assertThat(allSideRecruitingsPage.getContents().size()).isEqualTo(2);
+        assertThat(allSideRecruitingsPage.getPage()).isZero();
+        assertThat(allSideRecruitingsPage.getTotalPages()).isEqualTo(1);
+        assertThat(allSideRecruitingsPage.getContents().get(0).getProjectName()).isEqualTo(projectName);
+
+        assertThat(allSideRecruitingsPageWithFiltered.getContents().size()).isEqualTo(1);
+        assertThat(allSideRecruitingsPageWithFiltered.getContents().get(0).getField()).isEqualTo(Field.DESIGN);
+    }
+
+    @DisplayName("강의 모집글 검색 목록 조회 서비스 테스트 코드")
+    @Test
+    public void getRecruitingPageWithFilter() {
+        // given
+        Project lectureProjectWithSameDeaprtment = projectRepository.save(createLectureProject(department));
+        Project lectureProjectWithNonsameDepartment = projectRepository.save(createLectureProject(departmentRepository.save(Department.builder()
+                .university(university)
+                .collegeName("학교")
+                .region("부산")
+                .mainBranchType("main")
+                .name("다른 학과")
+                .build())));
+
+        Project savedSideProject = projectRepository.save(createSideProject());
+        Project afterSavedSideProject = projectRepository.save(createSideProject());
+        recruitingRepository.save(createRecruiting(member, lectureProjectWithNonsameDepartment, Type.LECTURE));
+        recruitingRepository.save(createRecruiting(member, lectureProjectWithSameDeaprtment, Type.LECTURE));
+        recruitingRepository.save(createRecruiting(member, savedSideProject, Type.SIDE));
+        recruitingRepository.save(createRecruiting(member, afterSavedSideProject, Type.SIDE));
+        // when
+        Pagination<RecruitingFind.ListResponseDto> allLectureRecruitingsPageSameWithDepartment = recruitingService.getSearchRecruitings(page, perSize, null, Type.LECTURE, null, account.getEmail()); // 전체 조회 (전공 학과 필터링)
+        Pagination<RecruitingFind.ListResponseDto> allLectureRecruitingsPageSameWithKeyword = recruitingService.getSearchRecruitings(page, perSize, null, Type.LECTURE, "test-professor" , account.getEmail()); // 검색 (검색어 필터링)
+
+        // then
+        Page<Recruiting> foundLectureRecruitingPagSameWithDepartment = recruitingRepository.findAllLectureBySearchWordAndDepartmentOrderByCreatedDate(null, member.getDepartment().getName(), pageable);
+        assertThat(allLectureRecruitingsPageSameWithDepartment.getContents().size()).isEqualTo(1);
+        assertThat(allLectureRecruitingsPageSameWithDepartment.getPage()).isZero();
+        LectureProject foundLectureProject = (LectureProject)foundLectureRecruitingPagSameWithDepartment.getContent().get(0).getProject();
+        assertThat(foundLectureProject.getDepartment().getName()).isEqualTo(member.getDepartment().getName());
+
+        assertThat(allLectureRecruitingsPageSameWithKeyword.getTotalCount()).isEqualTo(2);  // 교수명 검색 -> 전공 필터링X
+    }
 }


### PR DESCRIPTION
# 구현 내용/방법

1. `@JsonInclude(JsonInclude.Include.NON_NULL)` 애노테이션을 추가하여, null 값이 들어가는 필드들은 아예 JSON에 담기지 않도록 했습니다
2. 모집글의 타입에 따라 필터링 및 검색 조회 시 조건이 조금 다르기 때문에 각각의 쿼리 메서드를 생성했습니다. (`RecruitingRepositoryCustom.class` 참고!)
```
=> 검색 시, 강의와 사이드에 대한 쿼리 메서드를 각자 생성할지 같이 생성할 지 고민했는데 탭 마다 비교하는 게 조금씩 다르고,
현재 querydsl 작성 시 하위 레파지토리(Side, Lecture)를 직접 지정해줘야 한다고 판단해서 나눠서 진행했습니다!
```
3. 컨트롤러 메서드의 파라미터 인자로 사이드 탭과 강의 탭 모두 같은 API으로 받을 수 있도록 했습니다.  
(ex- 사이드에서만 쓰이는 field 파라미터인자는 강의 탭에서 요청 시 전달 X)
4. 기존에 있던 응답DTO(`RecruitingFind.class`)의 ListResponseDto 클래스에 필요한 필드 몇개 더 추가하여 공통으로 사용하도록 했습니다! (entity  -> DTO 변환 메서드만 추가로 생성했습니다.)

## 검색 정책
### 강의
- default : 전공(department)로 필터링 & 업로드 최신순 정렬
- 검색 : 전공, 강의명, 교수명&모집글 제목 중 일치하는 데이터 조회 (모든 학과에 상관없이 & 최신순 정렬)

### 사이드 : 
- default : 업로드 최신 순 정렬 (분야 전체. 즉, 필터링 X)
- 검색 : 프로젝트명&모집글 제목 중 일치하는 데이터 조회 (모든 분야에 상관없이 & 최신순 정렬)
- 검색 결과에서 필터링 추과할 경우 => 검색 데이터 + 분야 필터링 + 최신순 정렬

```
=> 최대한 제가 필요하다 생각 드는 경우의 수를 모두 테스트하였습니다! 
현재 Postman으로는 따로 실행해보지 않고 있어서 제한된 테스트를 했을 수 있을 것 같아 추후 이 부분은 다시 확인할 예정입니다. 
혹시 보시다가 필요한 테스트 케이스 생각나시면 말씀해주세요 :)
```

---

# 리뷰 필요
- querydsl로 작성한 메서드 확인 필요합니다 :)
- 이외에도 확인 필요한 부분 말씀 주시면 확인 및 수정하겠습니다!

close #99 
