### PR TITLE
feature/#68 리뷰 등록에 회원점수 적용

### DIFF
--- a/src/main/java/com/dnd/niceteam/domain/code/ReviewTag.java
+++ b/src/main/java/com/dnd/niceteam/domain/code/ReviewTag.java
@@ -6,9 +6,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ReviewTag implements EnumMapperType {
     RESPONSIBILITY("책임감 굿"),
-    DEAD_LINE("마감을 칼같이"),
+    PUNCTUALITY("마감을 칼같이"),
     MOOD_MAKER("분위기 메이커"),
     TIME_MANNERS("시간매너 끝판왕"),
+    POSITIVE("긍정 태도왕"),
+    IDEA("아이디어 요정"),
+    FEEDBACK("활발한 피드백"),
+    DECISIVE("속전속결 결정왕"),
+    LIKE_MINE("남의 일도 내 일같이"),
     ;
 
     private final String title;

--- a/src/main/java/com/dnd/niceteam/domain/memberscore/MemberScore.java
+++ b/src/main/java/com/dnd/niceteam/domain/memberscore/MemberScore.java
@@ -26,9 +26,11 @@ import static java.util.Objects.isNull;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberScore extends BaseEntity {
 
-    private static int[] scoreToFeedNum = {0, 0, 0, 1, 2, 2};
+    private static final int MAX_LEVEL = 4;
 
-    private static int levelUpFeedsNum = 10;
+    private static final int[] SCORE_TO_FEED_NUM = {0, 0, 0, 1, 2, 2};
+
+    private static final int LEVEL_UP_FEEDS_NUM = 10;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -93,7 +95,7 @@ public class MemberScore extends BaseEntity {
         totalParticipationScore += participationScore;
         totalTeamAgainScore += teamAgainScore;
         totalFeeds += feedWeight * feedNum;
-        level = (int) (totalFeeds / levelUpFeedsNum) + 1;
+        level = min((int) (totalFeeds / LEVEL_UP_FEEDS_NUM) + 1, MAX_LEVEL);
 
         review.getMemberReviewTags().stream()
                 .map(MemberReviewTag::getTag)
@@ -102,7 +104,7 @@ public class MemberScore extends BaseEntity {
     }
 
     private int calculateFeedNum(int participationScore, int teamAgainScore) {
-        return scoreToFeedNum[max(participationScore, scoreToFeedNum.length - 1)] +
-                scoreToFeedNum[max(teamAgainScore, scoreToFeedNum.length - 1)];
+        return SCORE_TO_FEED_NUM[min(max(participationScore, 0), SCORE_TO_FEED_NUM.length - 1)] +
+                SCORE_TO_FEED_NUM[min(max(teamAgainScore, 0), SCORE_TO_FEED_NUM.length - 1)];
     }
 }

--- a/src/main/java/com/dnd/niceteam/domain/memberscore/MemberScore.java
+++ b/src/main/java/com/dnd/niceteam/domain/memberscore/MemberScore.java
@@ -19,9 +19,13 @@ import static java.util.Objects.isNull;
 @Table(name = "member_score")
 @Where(clause = "use_yn = true")
 @SQLDelete(sql = "UPDATE member_score SET use_yn = false where member_score_id = ?")
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberScore extends BaseEntity {
+
+    private static int[] scoreToFeedNum = {0, 0, 0, 1, 2, 2};
+
+    private static int levelUpFeedsNum = 10;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,6 +44,10 @@ public class MemberScore extends BaseEntity {
     @Column(name = "total_team_again_score", nullable = false)
     private Integer totalTeamAgainScore;
 
+    @Column(name = "total_feeds", nullable = false)
+    @Builder.Default
+    private Double totalFeeds = 0D;
+
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "review_tag_num", joinColumns = @JoinColumn(name = "member_score_id", nullable = false))
     @MapKeyColumn(name = "review_tag", length = 45)
@@ -48,6 +56,18 @@ public class MemberScore extends BaseEntity {
     @Builder.Default
     private Map<ReviewTag, Integer> reviewTagToNums = IntStream.range(0, ReviewTag.values().length).boxed()
                     .collect(Collectors.toMap(i -> ReviewTag.values()[i], i -> 0));
+
+    public static MemberScore createInitMemberScore() {
+        return MemberScore.builder()
+                .level(1)
+                .reviewNum(0)
+                .totalParticipationScore(0)
+                .totalTeamAgainScore(0)
+                .totalFeeds(0D)
+                .reviewTagToNums(IntStream.range(0, ReviewTag.values().length).boxed()
+                        .collect(Collectors.toMap(i -> ReviewTag.values()[i], i -> 0)))
+                .build();
+    }
 
     public Double participationPct() {
         if (isNull(totalParticipationScore) || isNull(reviewNum)) {

--- a/src/main/java/com/dnd/niceteam/domain/memberscore/MemberScoreRepository.java
+++ b/src/main/java/com/dnd/niceteam/domain/memberscore/MemberScoreRepository.java
@@ -2,5 +2,5 @@ package com.dnd.niceteam.domain.memberscore;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberScoreRepository extends JpaRepository<MemberScore, Long> {
+public interface MemberScoreRepository extends JpaRepository<MemberScore, Long>, MemberScoreRepositoryCustom {
 }

--- a/src/main/java/com/dnd/niceteam/domain/memberscore/MemberScoreRepositoryCustom.java
+++ b/src/main/java/com/dnd/niceteam/domain/memberscore/MemberScoreRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.dnd.niceteam.domain.memberscore;
+
+import com.dnd.niceteam.domain.member.Member;
+
+import java.util.Optional;
+
+public interface MemberScoreRepositoryCustom {
+
+    Optional<MemberScore> findByMember(Member member);
+}

--- a/src/main/java/com/dnd/niceteam/domain/memberscore/MemberScoreRepositoryCustomImpl.java
+++ b/src/main/java/com/dnd/niceteam/domain/memberscore/MemberScoreRepositoryCustomImpl.java
@@ -1,0 +1,28 @@
+package com.dnd.niceteam.domain.memberscore;
+
+import com.dnd.niceteam.domain.member.Member;
+import com.dnd.niceteam.domain.member.QMember;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.dnd.niceteam.domain.memberscore.QMemberScore.*;
+
+@RequiredArgsConstructor
+public class MemberScoreRepositoryCustomImpl implements MemberScoreRepositoryCustom {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public Optional<MemberScore> findByMember(Member member) {
+        QMember qMember = QMember.member;
+        return Optional.ofNullable(query
+                .select(memberScore)
+                .from(qMember)
+                .join(qMember.memberScore, memberScore)
+                .where(qMember.eq(member))
+                .fetchOne()
+        );
+    }
+}

--- a/src/main/java/com/dnd/niceteam/domain/memberscore/exception/MemberScoreNotFoundException.java
+++ b/src/main/java/com/dnd/niceteam/domain/memberscore/exception/MemberScoreNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dnd.niceteam.domain.memberscore.exception;
+
+import com.dnd.niceteam.error.exception.BusinessException;
+import com.dnd.niceteam.error.exception.ErrorCode;
+
+public class MemberScoreNotFoundException extends BusinessException {
+
+    public MemberScoreNotFoundException(String message) {
+        super(ErrorCode.MEMBER_SCORE_NOT_FOUND, message);
+    }
+}

--- a/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
@@ -25,6 +25,8 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(MEMBER, SC_BAD_REQUEST, "존재하는 이메일입니다."),
     DUPLICATE_NICKNAME(MEMBER, SC_BAD_REQUEST, "존재하는 닉네임입니다."),
 
+    MEMBER_SCORE_NOT_FOUND(MEMBER_SCORE, SC_NOT_FOUND, "존재하지 않는 회원 점수 입니다."),
+
     UNIVERSITY_NOT_FOUND(UNIVERSITY, SC_NOT_FOUND, "존재하지 않는 대학교입니다."),
     INVALID_EMAIL_DOMAIN(UNIVERSITY, SC_BAD_REQUEST, "적절하지 않은 이메일 도메인입니다."),
 

--- a/src/main/java/com/dnd/niceteam/member/service/MemberService.java
+++ b/src/main/java/com/dnd/niceteam/member/service/MemberService.java
@@ -77,12 +77,7 @@ public class MemberService {
                 .email(requestDto.getEmail())
                 .password(passwordEncoder.encode(requestDto.getPassword()))
                 .build());
-        MemberScore memberScore = memberScoreRepository.save(MemberScore.builder()
-                .level(1)
-                .reviewNum(0)
-                .totalParticipationScore(0)
-                .totalTeamAgainScore(0)
-                .build());
+        MemberScore memberScore = memberScoreRepository.save(MemberScore.createInitMemberScore());
         Member member = memberRepository.save(Member.builder()
                 .account(account)
                 .university(department.getUniversity())

--- a/src/main/java/com/dnd/niceteam/review/service/MemberReviewService.java
+++ b/src/main/java/com/dnd/niceteam/review/service/MemberReviewService.java
@@ -2,6 +2,9 @@ package com.dnd.niceteam.review.service;
 
 import com.dnd.niceteam.domain.member.Member;
 import com.dnd.niceteam.domain.member.MemberRepository;
+import com.dnd.niceteam.domain.memberscore.MemberScore;
+import com.dnd.niceteam.domain.memberscore.MemberScoreRepository;
+import com.dnd.niceteam.domain.memberscore.exception.MemberScoreNotFoundException;
 import com.dnd.niceteam.domain.project.Project;
 import com.dnd.niceteam.domain.project.ProjectMember;
 import com.dnd.niceteam.domain.project.ProjectRepository;
@@ -26,6 +29,7 @@ public class MemberReviewService {
     private final MemberReviewRepository memberReviewRepository;
     private final MemberRepository memberRepository;
     private final ProjectRepository projectRepository;
+    private final MemberScoreRepository memberScoreRepository;
 
     @Transactional
     public void addMemberReview(MemberReviewRequest.Add request, User currentUser) {
@@ -35,7 +39,12 @@ public class MemberReviewService {
                 projectMember.reviewer,
                 projectMember.reviewee
         );
+        Member revieweeMember = projectMember.reviewee.getMember();
+        MemberScore memberScore = memberScoreRepository.findByMember(revieweeMember)
+                .orElseThrow(() -> new MemberScoreNotFoundException("memberId = " + revieweeMember.getId()));
+        int totalProjectMembers = projectMember.reviewee.getProject().getProjectMembers().size();
         memberReviewRepository.save(newMemberReview);
+        memberScore.applyReview(totalProjectMembers, newMemberReview);
     }
 
     @Transactional

--- a/src/test/java/com/dnd/niceteam/domain/memberscore/MemberScoreRepositoryTest.java
+++ b/src/test/java/com/dnd/niceteam/domain/memberscore/MemberScoreRepositoryTest.java
@@ -1,0 +1,91 @@
+package com.dnd.niceteam.domain.memberscore;
+
+import com.dnd.niceteam.common.TestJpaConfig;
+import com.dnd.niceteam.domain.account.Account;
+import com.dnd.niceteam.domain.account.AccountRepository;
+import com.dnd.niceteam.domain.code.Personality;
+import com.dnd.niceteam.domain.department.Department;
+import com.dnd.niceteam.domain.department.DepartmentRepository;
+import com.dnd.niceteam.domain.member.Member;
+import com.dnd.niceteam.domain.member.MemberRepository;
+import com.dnd.niceteam.domain.university.University;
+import com.dnd.niceteam.domain.university.UniversityRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Transactional
+@Import(TestJpaConfig.class)
+class MemberScoreRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private UniversityRepository universityRepository;
+
+    @Autowired
+    private DepartmentRepository departmentRepository;
+
+    @Autowired
+    private MemberScoreRepository memberScoreRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    void findByMember() {
+        // given
+        University university = universityRepository.save(University.builder()
+                .name("테스트대학교")
+                .emailDomain("email.com")
+                .build());
+        Department department = departmentRepository.save(Department.builder()
+                .university(university)
+                .collegeName("테스트단과대학")
+                .name("테스트학과")
+                .region("서울")
+                .mainBranchType("본교")
+                .build());
+        MemberScore memberScore = memberScoreRepository.save(MemberScore.builder()
+                .level(1)
+                .reviewNum(0)
+                .totalParticipationScore(0)
+                .totalTeamAgainScore(0)
+                .build());
+        Account account = accountRepository.save(Account.builder()
+                .email("test@email.com")
+                .password("test-password")
+                .build());
+        Member member = memberRepository.save(Member.builder()
+                .account(account)
+                .university(university)
+                .department(department)
+                .memberScore(memberScore)
+                .nickname("test-nickname")
+                .admissionYear(2017)
+                .personality(new Personality(Personality.Adjective.LOGICAL, Personality.Noun.LEADER))
+                .introduction("")
+                .introductionUrl("")
+                .build());
+        em.flush();
+        em.clear();
+
+        // when
+        Member foundMember = memberRepository.findById(member.getId()).orElseThrow();
+        MemberScore foundMemberScore = memberScoreRepository.findByMember(foundMember).orElseThrow();
+
+        // then
+        assertThat(foundMember.getMemberScore()).isEqualTo(foundMemberScore);
+    }
+}

--- a/src/test/java/com/dnd/niceteam/domain/memberscore/MemberScoreTest.java
+++ b/src/test/java/com/dnd/niceteam/domain/memberscore/MemberScoreTest.java
@@ -1,0 +1,29 @@
+package com.dnd.niceteam.domain.memberscore;
+
+import com.dnd.niceteam.domain.code.ReviewTag;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberScoreTest {
+
+    @Test
+    void createInitMemberScore() {
+        // when
+        MemberScore initMemberScore = MemberScore.createInitMemberScore();
+
+        // then
+        assertThat(initMemberScore.getId()).isNull();
+        assertThat(initMemberScore.getLevel()).isEqualTo(1);
+        assertThat(initMemberScore.getReviewNum()).isZero();
+        assertThat(initMemberScore.getTotalParticipationScore()).isZero();
+        assertThat(initMemberScore.getTotalTeamAgainScore()).isZero();
+        assertThat(initMemberScore.getTotalFeeds()).isZero();
+        assertThat(initMemberScore.getReviewTagToNums()).isEqualTo(
+                IntStream.range(0, ReviewTag.values().length).boxed()
+                        .collect(Collectors.toMap(i -> ReviewTag.values()[i], i -> 0)));
+    }
+}

--- a/src/test/java/com/dnd/niceteam/domain/memberscore/MemberScoreTest.java
+++ b/src/test/java/com/dnd/niceteam/domain/memberscore/MemberScoreTest.java
@@ -1,12 +1,18 @@
 package com.dnd.niceteam.domain.memberscore;
 
 import com.dnd.niceteam.domain.code.ReviewTag;
+import com.dnd.niceteam.domain.review.MemberReview;
+import com.dnd.niceteam.domain.review.MemberReviewTag;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 class MemberScoreTest {
 
@@ -25,5 +31,150 @@ class MemberScoreTest {
         assertThat(initMemberScore.getReviewTagToNums()).isEqualTo(
                 IntStream.range(0, ReviewTag.values().length).boxed()
                         .collect(Collectors.toMap(i -> ReviewTag.values()[i], i -> 0)));
+    }
+
+    @Test
+    void applyReview_TwoMember_OneReview() {
+        // given
+        MemberScore memberScore = MemberScore.createInitMemberScore();
+        MemberReview mockReview = mock(MemberReview.class);
+        given(mockReview.getSkipped()).willReturn(false);
+        given(mockReview.getParticipationScore()).willReturn(5);
+        given(mockReview.getTeamAgainScore()).willReturn(5);
+        given(mockReview.getMemberReviewTags())
+                .willReturn(Stream.of(ReviewTag.RESPONSIBILITY, ReviewTag.PUNCTUALITY)
+                        .map(reviewTag -> new MemberReviewTag(reviewTag, null))
+                        .collect(Collectors.toSet()));
+
+        // when
+        memberScore.applyReview(2, mockReview);
+
+        // then
+        assertThat(memberScore.getReviewNum()).isEqualTo(1);
+        assertThat(memberScore.getTotalParticipationScore()).isEqualTo(5);
+        assertThat(memberScore.getTotalTeamAgainScore()).isEqualTo(5);
+        assertThat(memberScore.getLevel()).isEqualTo(1);
+        assertThat(memberScore.getTotalFeeds()).isEqualTo(4);
+        assertThat(memberScore.getReviewTagToNums()).isEqualTo(Map.of(
+                ReviewTag.RESPONSIBILITY, 1,
+                ReviewTag.PUNCTUALITY, 1,
+                ReviewTag.MOOD_MAKER, 0,
+                ReviewTag.TIME_MANNERS, 0,
+                ReviewTag.POSITIVE, 0,
+                ReviewTag.IDEA, 0,
+                ReviewTag.FEEDBACK, 0,
+                ReviewTag.DECISIVE, 0,
+                ReviewTag.LIKE_MINE, 0
+        ));
+    }
+
+    @Test
+    void applyReview_ThreeMember_TwoReview() {
+        // given
+        MemberScore memberScore = MemberScore.createInitMemberScore();
+        MemberReview mockReview = mock(MemberReview.class);
+        given(mockReview.getSkipped()).willReturn(false);
+        given(mockReview.getParticipationScore()).willReturn(5);
+        given(mockReview.getTeamAgainScore()).willReturn(5);
+        given(mockReview.getMemberReviewTags())
+                .willReturn(Stream.of(ReviewTag.RESPONSIBILITY, ReviewTag.PUNCTUALITY)
+                        .map(reviewTag -> new MemberReviewTag(reviewTag, null))
+                        .collect(Collectors.toSet()));
+
+        // when
+        memberScore.applyReview(3, mockReview);
+        memberScore.applyReview(3, mockReview);
+
+        // then
+        assertThat(memberScore.getReviewNum()).isEqualTo(2);
+        assertThat(memberScore.getTotalParticipationScore()).isEqualTo(10);
+        assertThat(memberScore.getTotalTeamAgainScore()).isEqualTo(10);
+        assertThat(memberScore.getLevel()).isEqualTo(1);
+        assertThat(memberScore.getTotalFeeds()).isEqualTo(((Math.log(3) / Math.log(2)) / 2) * (4 + 4));
+        assertThat(memberScore.getReviewTagToNums()).isEqualTo(Map.of(
+                ReviewTag.RESPONSIBILITY, 2,
+                ReviewTag.PUNCTUALITY, 2,
+                ReviewTag.MOOD_MAKER, 0,
+                ReviewTag.TIME_MANNERS, 0,
+                ReviewTag.POSITIVE, 0,
+                ReviewTag.IDEA, 0,
+                ReviewTag.FEEDBACK, 0,
+                ReviewTag.DECISIVE, 0,
+                ReviewTag.LIKE_MINE, 0
+        ));
+    }
+
+    @Test
+    void applyReview_FourMember_ThreeReview() {
+        // given
+        MemberScore memberScore = MemberScore.createInitMemberScore();
+        MemberReview mockReview = mock(MemberReview.class);
+        given(mockReview.getSkipped()).willReturn(false);
+        given(mockReview.getParticipationScore()).willReturn(5);
+        given(mockReview.getTeamAgainScore()).willReturn(5);
+        given(mockReview.getMemberReviewTags())
+                .willReturn(Stream.of(ReviewTag.RESPONSIBILITY, ReviewTag.PUNCTUALITY)
+                        .map(reviewTag -> new MemberReviewTag(reviewTag, null))
+                        .collect(Collectors.toSet()));
+
+        // when
+        memberScore.applyReview(4, mockReview);
+        memberScore.applyReview(4, mockReview);
+        memberScore.applyReview(4, mockReview);
+
+        // then
+        assertThat(memberScore.getReviewNum()).isEqualTo(3);
+        assertThat(memberScore.getTotalParticipationScore()).isEqualTo(15);
+        assertThat(memberScore.getTotalTeamAgainScore()).isEqualTo(15);
+        assertThat(memberScore.getLevel()).isEqualTo(1);
+        assertThat(memberScore.getTotalFeeds()).isEqualTo(((Math.log(4) / Math.log(2)) / 3) * (4 + 4 + 4));
+        assertThat(memberScore.getReviewTagToNums()).isEqualTo(Map.of(
+                ReviewTag.RESPONSIBILITY, 3,
+                ReviewTag.PUNCTUALITY, 3,
+                ReviewTag.MOOD_MAKER, 0,
+                ReviewTag.TIME_MANNERS, 0,
+                ReviewTag.POSITIVE, 0,
+                ReviewTag.IDEA, 0,
+                ReviewTag.FEEDBACK, 0,
+                ReviewTag.DECISIVE, 0,
+                ReviewTag.LIKE_MINE, 0
+        ));
+    }
+
+    @Test
+    void applyReview_TwoMember_ThreeReview_LevelUp() {
+        // given
+        MemberScore memberScore = MemberScore.createInitMemberScore();
+        MemberReview mockReview = mock(MemberReview.class);
+        given(mockReview.getSkipped()).willReturn(false);
+        given(mockReview.getParticipationScore()).willReturn(5);
+        given(mockReview.getTeamAgainScore()).willReturn(5);
+        given(mockReview.getMemberReviewTags())
+                .willReturn(Stream.of(ReviewTag.RESPONSIBILITY, ReviewTag.PUNCTUALITY)
+                        .map(reviewTag -> new MemberReviewTag(reviewTag, null))
+                        .collect(Collectors.toSet()));
+
+        // when
+        memberScore.applyReview(2, mockReview);
+        memberScore.applyReview(2, mockReview);
+        memberScore.applyReview(2, mockReview);
+
+        // then
+        assertThat(memberScore.getReviewNum()).isEqualTo(3);
+        assertThat(memberScore.getTotalParticipationScore()).isEqualTo(15);
+        assertThat(memberScore.getTotalTeamAgainScore()).isEqualTo(15);
+        assertThat(memberScore.getLevel()).isEqualTo(2);
+        assertThat(memberScore.getTotalFeeds()).isEqualTo(12);
+        assertThat(memberScore.getReviewTagToNums()).isEqualTo(Map.of(
+                ReviewTag.RESPONSIBILITY, 3,
+                ReviewTag.PUNCTUALITY, 3,
+                ReviewTag.MOOD_MAKER, 0,
+                ReviewTag.TIME_MANNERS, 0,
+                ReviewTag.POSITIVE, 0,
+                ReviewTag.IDEA, 0,
+                ReviewTag.FEEDBACK, 0,
+                ReviewTag.DECISIVE, 0,
+                ReviewTag.LIKE_MINE, 0
+        ));
     }
 }

--- a/src/test/java/com/dnd/niceteam/review/MemberReviewTestFactory.java
+++ b/src/test/java/com/dnd/niceteam/review/MemberReviewTestFactory.java
@@ -11,7 +11,7 @@ public class MemberReviewTestFactory {
 
     public static MemberReviewRequest.Add getAddRequest(Long revieweeId) {
         MemberReviewRequest.Add request = new MemberReviewRequest.Add();
-        Set<ReviewTag> reviewTags = new HashSet<>(List.of(ReviewTag.RESPONSIBILITY, ReviewTag.DEAD_LINE));
+        Set<ReviewTag> reviewTags = new HashSet<>(List.of(ReviewTag.RESPONSIBILITY, ReviewTag.PUNCTUALITY));
 
         request.setParticipationScore(5);
         request.setTeamAgainScore(4);

--- a/src/test/java/com/dnd/niceteam/review/service/MemberReviewServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/review/service/MemberReviewServiceTest.java
@@ -2,6 +2,8 @@ package com.dnd.niceteam.review.service;
 
 import com.dnd.niceteam.domain.member.Member;
 import com.dnd.niceteam.domain.member.MemberRepository;
+import com.dnd.niceteam.domain.memberscore.MemberScore;
+import com.dnd.niceteam.domain.memberscore.MemberScoreRepository;
 import com.dnd.niceteam.domain.project.*;
 import com.dnd.niceteam.domain.review.MemberReview;
 import com.dnd.niceteam.domain.review.MemberReviewRepository;
@@ -23,6 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,6 +40,8 @@ class MemberReviewServiceTest {
     MemberRepository memberRepository;
     @Mock
     ProjectRepository projectRepository;
+    @Mock
+    MemberScoreRepository memberScoreRepository;
 
     static final long reviwerId = 1L;
     static final long revieweeId = 2L;
@@ -82,11 +87,15 @@ class MemberReviewServiceTest {
         Set<ProjectMember> projectMembers = new HashSet<>(List.of(reviewer, reviewee));
         when(project.getProjectMembers()).thenReturn(projectMembers);
 
+        MemberScore memberScore = mock(MemberScore.class);
+        when(memberScoreRepository.findByMember(reviewee.getMember())).thenReturn(Optional.of(memberScore));
+
         // when
         memberReviewService.addMemberReview(request, currentUser);
 
         // then
         verify(memberReviewRepository).save(any(MemberReview.class));
+        then(memberScore).should().applyReview(anyInt(), any(MemberReview.class));
     }
 
     @DisplayName("팀원 후기 건너뛰기")


### PR DESCRIPTION
# 구현 내용/방법

> 간단하게 구현한 내용과 방법에 대한 설명

- MemberReviewService 에서 리뷰 등록에 회원 점수 반영
- 성장 먹이 개수 10
- 점수에 따른 먹이 개수
  - 0점 -> 0개
  - 1점 -> 0개
  - 2점 -> 0개
  - 3점 -> 1개
  - 4점 -> 2개
  - 5점 -> 2개
- 가중치 = 팀원 모두가 리뷰했을 때 받을 수 있는 총점 가중치 ( log(프로젝트 멤버수) / log2 ) / 프로젝트에서 받을 수 있는 리뷰 수

# 리뷰 필요

> 나중에 다시 고민해야할 내용이 있는 내용  
> 없을 경우 작성 X
> 있을 경우 작성 후 이슈 남기고 해당 PR 링크

- 

close #68 
