### PR TITLE
Feature/#104 모집글 제거, 수정

### DIFF
--- a/src/docs/asciidoc/recruiting.adoc
+++ b/src/docs/asciidoc/recruiting.adoc
@@ -34,3 +34,13 @@ operation::recruiting-recommend-side[snippets='http-request,request-parameters,h
 == 모집글 검색 목록 조회
 
 operation::recruiting-search-list[snippets='http-request,request-parameters,http-response,response-fields-data']
+
+[[recruiting-modify]]
+== 모집글 수정
+
+operation::recruiting-modify[snippets='http-request,request-parameters,http-response,response-fields-data']
+
+[[recruiting-remove]]
+== 모집글 제거
+
+operation::recruiting-remove[snippets='http-request,request-parameters,http-response,response-fields-data']

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/Recruiting.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/Recruiting.java
@@ -4,6 +4,8 @@ import com.dnd.niceteam.domain.code.*;
 import com.dnd.niceteam.domain.common.BaseEntity;
 import com.dnd.niceteam.domain.member.Member;
 import com.dnd.niceteam.domain.project.Project;
+import com.dnd.niceteam.recruiting.dto.ActivityDayTimeDto;
+import com.dnd.niceteam.recruiting.dto.RecruitingModify;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
@@ -13,6 +15,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Entity
 @Builder
@@ -29,7 +32,7 @@ public class Recruiting extends BaseEntity {
     @Column(name = "recruiting_id")
     private Long id;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
     @JoinColumn(name = "project_id", nullable = false)
     private Project project;
 
@@ -105,6 +108,10 @@ public class Recruiting extends BaseEntity {
         this.commentCount += 1;
     }
 
+    public void minusCommentCount() {
+        this.commentCount -= 1;
+    }
+
     public void updateStatus(ProgressStatus status) {
         this.status = status;
     }
@@ -119,5 +126,19 @@ public class Recruiting extends BaseEntity {
 
     public boolean checkRecruiter(Member member) {
         return this.member.equals(member);
+    }
+
+    public void update(RecruitingModify.RequestDto dto) {
+        title = dto.getTitle();
+        content = dto.getContent();
+        recruitingMemberCount = dto.getRecruitingMemberCount();
+        recruitingType = dto.getRecruitingType();
+        recruitingType = dto.getRecruitingType();
+        activityArea = dto.getActivityArea();
+        introLink = dto.getIntroLink();
+        recruitingEndDate = dto.getRecruitingEndDate();
+        activityDayTimes = dto.getActivityDayTimes().stream().map(ActivityDayTimeDto::toEntity).collect(Collectors.toSet());   // dto로 수정 필요.
+        personalityAdjectives = dto.getPersonalityAdjectives();
+        personalityNouns = dto.getPersonalityNouns();
     }
 }

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/RecruitingRepositoryCustomImpl.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/RecruitingRepositoryCustomImpl.java
@@ -136,7 +136,7 @@ public class RecruitingRepositoryCustomImpl implements RecruitingRepositoryCusto
                 .leftJoin(sideProject).on(sideProject.eq(project))
                 .where(
                         nameContains(sideProject.name, searchWord)
-                                .and(fieldEq(field))    // searchWord가 null이면 무시하고, 필드가 같아야 한다.)
+                                .and(fieldEq(field))
                 )
                 .fetch();
     }

--- a/src/main/java/com/dnd/niceteam/project/dto/ProjectRequest.java
+++ b/src/main/java/com/dnd/niceteam/project/dto/ProjectRequest.java
@@ -8,6 +8,9 @@ import com.dnd.niceteam.domain.project.LectureProject;
 import com.dnd.niceteam.domain.project.LectureTime;
 import com.dnd.niceteam.domain.project.ProjectStatus;
 import com.dnd.niceteam.domain.project.SideProject;
+import com.dnd.niceteam.domain.recruiting.exception.InvalidRecruitingTypeException;
+import com.dnd.niceteam.recruiting.dto.RecruitingCreation;
+import com.dnd.niceteam.recruiting.dto.RecruitingModify;
 import lombok.Data;
 
 import java.time.LocalDate;
@@ -60,6 +63,29 @@ public interface ProjectRequest {
                     .fieldCategory(fieldCategory)
                     .build();
         }
+
+        public static ProjectRequest.Register createProjecRegistertRequestDto(RecruitingCreation.RequestDto recruitingReqDto) {
+            ProjectRequest.Register projectDto = new ProjectRequest.Register();
+            projectDto.setType(recruitingReqDto.getRecruitingType());
+            projectDto.setStartDate(recruitingReqDto.getProjectStartDate());
+            projectDto.setEndDate(recruitingReqDto.getProjectEndDate());
+            projectDto.setName(recruitingReqDto.getProjectName());
+
+            switch (recruitingReqDto.getRecruitingType()) {
+                case SIDE:
+                    projectDto.setField(recruitingReqDto.getField());
+                    projectDto.setFieldCategory(recruitingReqDto.getFieldCategory());
+                    break;
+                case LECTURE:
+                    projectDto.setProfessor(recruitingReqDto.getProfessor());
+                    projectDto.setDepartmentId(recruitingReqDto.getDepartmentId());
+                    projectDto.setLectureTimes(recruitingReqDto.getLectureTimes());
+                    break;
+                default:
+                    throw new InvalidRecruitingTypeException("Unexpected Type: " + recruitingReqDto.getRecruitingType());
+            }
+            return projectDto;
+        }
     }
 
 
@@ -80,6 +106,27 @@ public interface ProjectRequest {
         private Field field;
         private FieldCategory fieldCategory;
 
+        public static ProjectRequest.Update createProjectUpdateRequestDto (RecruitingModify.RequestDto requestDto) {
+            ProjectRequest.Update dto = new ProjectRequest.Update();
+            dto.setName(requestDto.getProjectName());
+            dto.setStartDate(requestDto.getProjectStartDate());
+            dto.setEndDate(requestDto.getProjectEndDate());
+
+            switch (requestDto.getRecruitingType()) {
+                case SIDE:
+                    dto.setField(requestDto.getField());
+                    dto.setFieldCategory(requestDto.getFieldCategory());
+                    break;
+                case LECTURE:
+                    dto.setProfessor(requestDto.getProfessor());
+                    dto.setDepartmentId(requestDto.getDepartmentId());
+                    dto.setLectureTimes(requestDto.getLectureTimes());
+                    break;
+                default:
+                    throw new InvalidRecruitingTypeException("Unexpected Type: " + requestDto.getRecruitingType());
+            }
+            return dto;
+        }
     }
 
 }

--- a/src/main/java/com/dnd/niceteam/recruiting/controller/RecruitingController.java
+++ b/src/main/java/com/dnd/niceteam/recruiting/controller/RecruitingController.java
@@ -7,6 +7,7 @@ import com.dnd.niceteam.domain.code.ProgressStatus;
 import com.dnd.niceteam.domain.code.Type;
 import com.dnd.niceteam.recruiting.dto.RecruitingCreation;
 import com.dnd.niceteam.recruiting.dto.RecruitingFind;
+import com.dnd.niceteam.recruiting.dto.RecruitingModify;
 import com.dnd.niceteam.recruiting.service.RecruitingService;
 import com.dnd.niceteam.security.CurrentUsername;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 @RequiredArgsConstructor
@@ -24,7 +26,7 @@ public class RecruitingController {
     private final RecruitingService recruitingService;
 
     @PostMapping
-    public ResponseEntity<ApiResult<RecruitingCreation.ResponseDto>> recruitingAdd (@RequestBody RecruitingCreation.RequestDto recruitingReqDto) {
+    public ResponseEntity<ApiResult<RecruitingCreation.ResponseDto>> recruitingAdd (@RequestBody @Valid RecruitingCreation.RequestDto recruitingReqDto) {
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
         RecruitingCreation.ResponseDto responseDto = recruitingService.addProjectAndRecruiting(username, recruitingReqDto);
 
@@ -80,6 +82,22 @@ public class RecruitingController {
         Pagination<RecruitingFind.ListResponseDto> recruitings = recruitingService.getSearchRecruitings(page, perSize, field, type, searchWord, username);
 
         ApiResult<Pagination<RecruitingFind.ListResponseDto>> apiResult = ApiResult.success(recruitings);
+        return ResponseEntity.ok(apiResult);
+    }
+
+    @PutMapping("/{recruitingId}")
+    public ResponseEntity<ApiResult<RecruitingModify.ResponseDto>> recruitingModify (@PathVariable @NotNull Long recruitingId,
+                                                                                     @RequestBody RecruitingModify.RequestDto requestDto) {
+        RecruitingModify.ResponseDto updatedRecruiting = recruitingService.modifyProjectAndRecruiting(recruitingId, requestDto);
+        ApiResult<RecruitingModify.ResponseDto> apiResult = ApiResult.success(updatedRecruiting);
+        return ResponseEntity.ok(apiResult);
+    }
+
+    @DeleteMapping("/{recruitingId}")
+    public ResponseEntity<ApiResult<Void>> recruitingRemove (@PathVariable @NotNull Long recruitingId) {
+        recruitingService.removeRecruiting(recruitingId);
+
+        ApiResult<Void> apiResult = ApiResult.<Void>success().build();
         return ResponseEntity.ok(apiResult);
     }
 }

--- a/src/main/java/com/dnd/niceteam/recruiting/dto/RecruitingModify.java
+++ b/src/main/java/com/dnd/niceteam/recruiting/dto/RecruitingModify.java
@@ -1,23 +1,18 @@
 package com.dnd.niceteam.recruiting.dto;
 
 import com.dnd.niceteam.domain.code.*;
-import com.dnd.niceteam.domain.member.Member;
-import com.dnd.niceteam.domain.project.Project;
-import com.dnd.niceteam.domain.recruiting.ActivityDayTime;
 import com.dnd.niceteam.domain.recruiting.Recruiting;
 import com.dnd.niceteam.project.dto.LectureTimeRequest;
 import lombok.Data;
 import org.springframework.lang.Nullable;
 
-import javax.validation.constraints.FutureOrPresent;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-// TODO: 2022-08-22 Validation 추가 필요 
-public interface RecruitingCreation {
+public interface RecruitingModify {
+    // 수정 (바뀌지 않은 것도 담아서 보내는 방식)
     @Data
     class RequestDto {
         @NotNull
@@ -32,9 +27,6 @@ public interface RecruitingCreation {
         private ActivityArea activityArea;
         @NotNull
         private String introLink;
-        @NotNull
-        private ProgressStatus status;
-        @FutureOrPresent
         @Nullable
         private LocalDate recruitingEndDate;    // 기간이 정해져있지 않으면 null
         @NotNull
@@ -63,44 +55,15 @@ public interface RecruitingCreation {
         private Field field;
         @Nullable
         private FieldCategory fieldCategory;
-
-        public Recruiting toEntity(Project project, Member member) {
-            return Recruiting.builder()
-                    .project(project)
-                    .member(member)
-                    .title(title)
-                    .content(content)
-                    .recruitingMemberCount(recruitingMemberCount)
-                    .recruitingType(recruitingType)
-                    .activityArea(activityArea)
-                    .activityDayTimes(convertToEntity(activityDayTimes))
-                    .recruitingEndDate(recruitingEndDate)
-                    .bookmarkCount(0)
-                    .commentCount(0)
-                    .poolUpCount(0)
-                    .poolUpDate(null)
-                    .introLink(introLink)
-                    .personalityAdjectives(personalityAdjectives)
-                    .personalityNouns(personalityNouns)
-                    .build();
-        }
-
-        private Set<ActivityDayTime> convertToEntity(Set<ActivityDayTimeDto> activityDayTimes) {
-            return activityDayTimes.stream()
-                    .map(ActivityDayTimeDto::toEntity).collect(Collectors.toSet());
-        }
     }
 
     @Data
     class ResponseDto {
-        @NotNull
         private Long recruitingId;
-
-        @NotNull
         private Long projectId;
 
-        public static RecruitingCreation.ResponseDto from(Recruiting recruiting) {
-            ResponseDto dto = new ResponseDto();
+        public static RecruitingModify.ResponseDto from(Recruiting recruiting) {
+            RecruitingModify.ResponseDto dto = new RecruitingModify.ResponseDto();
 
             dto.setRecruitingId(recruiting.getId());
             dto.setProjectId(recruiting.getProject().getId());

--- a/src/test/java/com/dnd/niceteam/comment/DtoFactoryForTest.java
+++ b/src/test/java/com/dnd/niceteam/comment/DtoFactoryForTest.java
@@ -7,6 +7,7 @@ import com.dnd.niceteam.project.dto.ProjectResponse;
 import com.dnd.niceteam.recruiting.dto.ActivityDayTimeDto;
 import com.dnd.niceteam.recruiting.dto.RecruitingCreation;
 import com.dnd.niceteam.recruiting.dto.RecruitingFind;
+import com.dnd.niceteam.recruiting.dto.RecruitingModify;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -20,8 +21,11 @@ public class DtoFactoryForTest {
     public static final Long RECRUITING_ID = 1L;
     public static final Long PROJECT_ID = 1L;
     public static final Long DEPARTMENT_ID = 1L;
+    public static final int page = 1;
+    public static final int perSize = 5;
+    public static final Long recruitingId = 1L;
 
-    public static CommentCreation.RequestDto createCommentRequest() {
+    public static CommentCreation.RequestDto createCommentAddRequest() {
         CommentCreation.RequestDto dto = new CommentCreation.RequestDto();
         dto.setContent(COMMENT_CONTENT);
         dto.setParentId(PARENT_ID);
@@ -29,9 +33,12 @@ public class DtoFactoryForTest {
     }
 
     public static final Long COMMENT_ID = 1L;
-    public static CommentCreation.ResponseDto createCommentResponse() {
+    public static final Long GROUP_NO = 1L;
+    public static CommentCreation.ResponseDto createCommentAddResponse() {
         CommentCreation.ResponseDto dto = new CommentCreation.ResponseDto();
         dto.setId(COMMENT_ID);
+        dto.setParentId(PARENT_ID);
+        dto.setGroupNo(GROUP_NO);
         return dto;
     }
 
@@ -40,7 +47,7 @@ public class DtoFactoryForTest {
         dto.setTitle("모집글 제목 테스트");
         dto.setContent("모집글 내용 테스트");
         dto.setRecruitingType(Type.LECTURE);
-        dto.setRecruitingEndDate(LocalDate.of(2022, 8, 16));
+        dto.setRecruitingEndDate(LocalDate.of(2023, 8, 28));
         dto.setActivityArea(ActivityArea.ONLINE);
         dto.setStatus(ProgressStatus.IN_PROGRESS);
         dto.setRecruitingMemberCount(3);
@@ -49,8 +56,8 @@ public class DtoFactoryForTest {
         dto.setPersonalityNouns(Set.of(Personality.Noun.INVENTOR, Personality.Noun.MEDIATOR));
         dto.setActivityDayTimes(createActivityDayTimesDto());
 
-        dto.setProjectStartDate(LocalDate.of(2022, 7, 4));
-        dto.setProjectEndDate(LocalDate.of(2022, 8, 28));
+        dto.setProjectStartDate(LocalDate.of(2023, 8, 29));
+        dto.setProjectEndDate(LocalDate.of(2023, 12, 28));
 
         dto.setProjectName("project-name");
         dto.setDepartmentId(DEPARTMENT_ID);
@@ -155,5 +162,38 @@ public class DtoFactoryForTest {
         responseDto.setField(Field.IT_SW_GAME);
         responseDto.setFieldCategory(FieldCategory.STUDY);
         return responseDto;
+    }
+
+    public static RecruitingModify.RequestDto createRecruitingModifyRequest() {
+        RecruitingModify.RequestDto dto = new RecruitingModify.RequestDto();
+        dto.setTitle("모집글 제목 테스트");
+        dto.setContent("모집글 내용 테스트");
+        dto.setRecruitingType(Type.LECTURE);
+        dto.setRecruitingEndDate(LocalDate.of(2022, 8, 16));
+        dto.setActivityArea(ActivityArea.ONLINE);
+        dto.setRecruitingMemberCount(3);
+        dto.setIntroLink("test-intro");
+        dto.setPersonalityAdjectives(Set.of(Personality.Adjective.PRECISE, Personality.Adjective.CREATIVE));
+        dto.setPersonalityNouns(Set.of(Personality.Noun.INVENTOR, Personality.Noun.MEDIATOR));
+        dto.setActivityDayTimes(createActivityDayTimesDto());
+
+        dto.setProjectStartDate(LocalDate.of(2022, 7, 4));
+        dto.setProjectEndDate(LocalDate.of(2022, 8, 28));
+
+        dto.setProjectName("project-name");
+        dto.setDepartmentId(DEPARTMENT_ID);
+        dto.setProfessor("test-professor");
+        dto.setLectureTimes(createLectureTimeRequest());
+
+        if (dto.getRecruitingType() == Type.LECTURE) {
+            dto.setDepartmentId(DEPARTMENT_ID);
+            dto.setProfessor("test-professor");
+            dto.setLectureTimes(createLectureTimeRequest());
+        } else {
+            dto.setField(Field.AD_MARKETING);
+            dto.setFieldCategory(FieldCategory.STUDY);
+        }
+
+        return dto;
     }
 }

--- a/src/test/java/com/dnd/niceteam/recruiting/service/RecruitingServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/recruiting/service/RecruitingServiceTest.java
@@ -5,16 +5,14 @@ import com.dnd.niceteam.common.TestJpaConfig;
 import com.dnd.niceteam.common.dto.Pagination;
 import com.dnd.niceteam.domain.account.Account;
 import com.dnd.niceteam.domain.account.AccountRepository;
-import com.dnd.niceteam.domain.code.Field;
-import com.dnd.niceteam.domain.code.FieldCategory;
-import com.dnd.niceteam.domain.code.ProgressStatus;
-import com.dnd.niceteam.domain.code.Type;
+import com.dnd.niceteam.domain.code.*;
 import com.dnd.niceteam.domain.department.Department;
 import com.dnd.niceteam.domain.department.DepartmentRepository;
 import com.dnd.niceteam.domain.member.Member;
 import com.dnd.niceteam.domain.member.MemberRepository;
 import com.dnd.niceteam.domain.memberscore.MemberScore;
 import com.dnd.niceteam.domain.memberscore.MemberScoreRepository;
+import com.dnd.niceteam.domain.project.LectureProject;
 import com.dnd.niceteam.domain.project.Project;
 import com.dnd.niceteam.domain.project.ProjectRepository;
 import com.dnd.niceteam.domain.project.SideProject;
@@ -28,6 +26,7 @@ import com.dnd.niceteam.project.service.ProjectMemberService;
 import com.dnd.niceteam.project.service.ProjectService;
 import com.dnd.niceteam.recruiting.dto.RecruitingCreation;
 import com.dnd.niceteam.recruiting.dto.RecruitingFind;
+import com.dnd.niceteam.recruiting.dto.RecruitingModify;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,9 +40,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import java.time.LocalDate;
+import java.util.Set;
 
 import static com.dnd.niceteam.comment.EntityFactoryForTest.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DataJpaTest
 @Import({TestJpaConfig.class, RecruitingService.class, ProjectService.class, ProjectMemberService.class})
@@ -69,6 +70,8 @@ class RecruitingServiceTest {
 
     @Autowired
     private ProjectRepository projectRepository;
+    @Autowired
+    private ProjectService projectService;
 
     @Autowired
     private EntityManager em;
@@ -299,5 +302,44 @@ class RecruitingServiceTest {
         assertThat(foundLectureProject.getDepartment().getName()).isEqualTo(member.getDepartment().getName());
 
         assertThat(allLectureRecruitingsPageSameWithKeyword.getTotalCount()).isEqualTo(2);  // 교수명 검색 -> 전공 필터링X
+    }
+
+    // TODO: 2022-08-23 PROJECT_NOT_FOUND 해결 필요
+    @DisplayName("(LECTURE) 모집글 수정 서비스 테스트 코드")
+    @Test
+    public void modifyRecruiting() {
+        // given
+        Project savedLectureProject = projectRepository.save(createLectureProject(department));
+        Recruiting savedRecruiting = recruitingRepository.save(createRecruiting(member, savedLectureProject, Type.LECTURE));
+        RecruitingModify.RequestDto recruitingReqDto = DtoFactoryForTest.createRecruitingModifyRequest();
+        recruitingReqDto.setActivityArea(ActivityArea.BUSAN);
+        recruitingReqDto.setPersonalityNouns(Set.of(Personality.Noun.JACK_OF_ALL_TRADES));
+        recruitingReqDto.setRecruitingMemberCount(savedRecruiting.getRecruitingMemberCount()+1);    // update
+
+        //when
+        RecruitingModify.ResponseDto recruitingResDto = recruitingService.modifyProjectAndRecruiting(savedRecruiting.getId(), recruitingReqDto);
+
+        //then
+        Recruiting updatedRecruiting = recruitingRepository.findById(savedRecruiting.getId())
+                .orElseThrow(() -> new RecruitingNotFoundException("recruiting id : " + savedRecruiting.getId()));
+        assertThat(savedRecruiting.getActivityArea()).isNotEqualTo(updatedRecruiting.getActivityArea());
+        assertThat(savedRecruiting.getPersonalityNouns()).isNotEqualTo(updatedRecruiting.getPersonalityNouns());
+        assertThat(savedRecruiting.getPersonalityAdjectives()).isEqualTo(updatedRecruiting.getPersonalityAdjectives());
+
+        assertThat(recruitingResDto.getProjectId()).isEqualTo(updatedRecruiting.getProject().getId());
+    }
+
+    @DisplayName("모집글 제거 서비스 테스트 코드")
+    @Test
+    public void removeRecruiting() {
+        // given
+        Project saveSideProject = projectRepository.save(createSideProject());
+        Recruiting savedRecruiting = recruitingRepository.save(createRecruiting(member, saveSideProject, Type.SIDE));
+        // when
+        recruitingService.removeRecruiting(savedRecruiting.getId());
+
+        // expected
+        assertThatThrownBy(() -> recruitingService.getRecruiting(savedRecruiting.getId(), account.getEmail()))
+                .isInstanceOf(RecruitingNotFoundException.class);
     }
 }


### PR DESCRIPTION
# 구현 내용/방법

1. 기존에 RecruitingService에 있던 `setProjectUpdateRequestDto(~)`와 `setProjecRegistertRequestDto(~)` 메서드를 `ProjectRequest.class`로 옮겼습니다!
2. 모집글 제거 시 프로젝트가 아직 시작되지 않았다면(`NOT_STARTED`), 프로젝트도 함께 제거하도록 했습니다.


# 리뷰 필요
- slack에서 말씀드렸던 부분 : `(LECTURE) 모집글 수정 서비스 테스트 코드` 와 `(Lecture)신규 모집글 작성 서비스 테스트 코드`가 각각 프로젝트 NotFound, 학과 NotFound가 뜨는 문제가 있어 전체 테스트 중 확인할 예정입니다.

close #104 
