### PR TITLE
Feature/#114 Applicant 지원 현황 목록 조회

### DIFF
--- a/src/docs/asciidoc/applicant.adoc
+++ b/src/docs/asciidoc/applicant.adoc
@@ -17,3 +17,9 @@ operation::applicant-create[snippets='http-request,request-fields,http-response,
 == 지원 취소
 
 operation::applicant-delete[snippets='http-request,request-fields,http-response,response-fields-data']
+
+
+[[my-applicant-list]]
+== 지원 현황 목록 조회
+
+operation::my-applicant-list[snippets='http-request,request-parameters,http-response,response-fields-data']

--- a/src/main/java/com/dnd/niceteam/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/dnd/niceteam/applicant/controller/ApplicantController.java
@@ -1,8 +1,10 @@
 package com.dnd.niceteam.applicant.controller;
 
 import com.dnd.niceteam.applicant.dto.ApplicantCreation;
+import com.dnd.niceteam.applicant.dto.ApplicantFind;
 import com.dnd.niceteam.applicant.service.ApplicantService;
 import com.dnd.niceteam.common.dto.ApiResult;
+import com.dnd.niceteam.common.dto.Pagination;
 import com.dnd.niceteam.security.CurrentUsername;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,27 +15,34 @@ import javax.validation.constraints.NotNull;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/recruiting/{recruitingId}/applicant")
+@RequestMapping("/recruiting")
 public class ApplicantController {
     private final ApplicantService applicantService;
 
-    @PostMapping
-    public ResponseEntity<ApiResult<ApplicantCreation.ResponseDto>> applicantAdd (@PathVariable @NotNull Long recruitingId,
-                                                                                  @CurrentUsername String username) {
+    @PostMapping("/{recruitingId}/applicant")
+    public ResponseEntity<ApiResult<ApplicantCreation.ResponseDto>> applicantAdd(@PathVariable @NotNull Long recruitingId,
+                                                                                 @CurrentUsername String username) {
         ApplicantCreation.ResponseDto responseDto = applicantService.addApplicant(recruitingId, username);
-
-        // TODO: 2022-08-18 팀원 등록도 추가 예정
 
         return new ResponseEntity<>(ApiResult.success(responseDto), HttpStatus.CREATED);
     }
 
-    @DeleteMapping
-    public ResponseEntity<ApiResult<Void>> applicantRemove (@PathVariable @NotNull Long recruitingId,
-                                                            @CurrentUsername String username) {
+    @DeleteMapping("/{recruitingId}/applicant")
+    public ResponseEntity<ApiResult<Void>> applicantRemove(@PathVariable @NotNull Long recruitingId,
+                                                           @CurrentUsername String username) {
         applicantService.removeApplicant(recruitingId, username);
 
         ApiResult<Void> apiResult = ApiResult.<Void>success().build();
         return ResponseEntity.ok(apiResult);
     }
 
+    @GetMapping("/applicant/me")
+    public ResponseEntity<ApiResult<Pagination<ApplicantFind.ListResponseDto>>> myApplyList(@RequestParam(defaultValue = "1", required = false) Integer page,
+                                                                                            @RequestParam(defaultValue = "10", required = false) Integer perSize,
+                                                                                            @RequestBody ApplicantFind.ListRequestDto requestDto,
+                                                                                            @CurrentUsername String username) {
+        Pagination<ApplicantFind.ListResponseDto> applications = applicantService.getMyApplicnts(page, perSize, requestDto, username);
+        ApiResult<Pagination<ApplicantFind.ListResponseDto>> apiResult = ApiResult.success(applications);
+        return ResponseEntity.ok(apiResult);
+    }
 }

--- a/src/main/java/com/dnd/niceteam/applicant/dto/ApplicantFind.java
+++ b/src/main/java/com/dnd/niceteam/applicant/dto/ApplicantFind.java
@@ -1,0 +1,32 @@
+package com.dnd.niceteam.applicant.dto;
+
+import com.dnd.niceteam.domain.recruiting.Applicant;
+import com.dnd.niceteam.domain.recruiting.RecruitingStatus;
+import lombok.Data;
+
+public interface ApplicantFind {
+    @Data
+    class ListRequestDto {
+        RecruitingStatus recruitingStatus;
+        Boolean applicantJoined;
+    }
+
+    @Data
+    class ListResponseDto {
+        Long recruitingId;
+        RecruitingStatus recruitingStatus;
+        Boolean joined;
+        String projectName;
+        Integer recruitingMemberCount;
+
+        public static ListResponseDto from (Applicant applicant) {
+            ListResponseDto dto = new ListResponseDto();
+            dto.setRecruitingId(applicant.getRecruiting().getId());
+            dto.setRecruitingStatus(applicant.getRecruiting().getStatus());
+            dto.setJoined(applicant.getJoined());
+            dto.setProjectName(applicant.getRecruiting().getProject().getName());   // 모집글의 제목은 어떨지
+            dto.setRecruitingMemberCount(applicant.getRecruiting().getRecruitingMemberCount());
+            return dto;
+        }
+    }
+}

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/ApplicantRepository.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/ApplicantRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
+public interface ApplicantRepository extends JpaRepository<Applicant, Long>, ApplicantRepositoryCustom {
     Optional<Applicant> findByMemberIdAndRecruitingId(Long memberId, Long recruitingId);
 }

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/ApplicantRepositoryCustom.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/ApplicantRepositoryCustom.java
@@ -1,9 +1,10 @@
 package com.dnd.niceteam.domain.recruiting;
 
 import com.dnd.niceteam.domain.member.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ApplicantRepositoryCustom {
-
-    Applicant findApplicantByMemberAndRecruiting(Member member, Recruiting recruiting);
-
+    Page<Applicant> findAllByMemberAndRecruitingStatusAndJoinedOrderByCreatedDateDesc(Member member, RecruitingStatus recruitingStatus,
+                                                                                      Boolean applicantJoined, Pageable pageable);
 }

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/ApplicantRepositoryCustomImpl.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/ApplicantRepositoryCustomImpl.java
@@ -1,8 +1,15 @@
 package com.dnd.niceteam.domain.recruiting;
 
 import com.dnd.niceteam.domain.member.Member;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanPath;
+import com.querydsl.core.types.dsl.EnumPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 import static com.dnd.niceteam.domain.recruiting.QApplicant.applicant;
 
@@ -11,13 +18,47 @@ public class ApplicantRepositoryCustomImpl implements ApplicantRepositoryCustom{
     private final JPAQueryFactory query;
 
     @Override
-    public Applicant findApplicantByMemberAndRecruiting(Member member, Recruiting recruiting) {
-        return query
+    public PageImpl<Applicant> findAllByMemberAndRecruitingStatusAndJoinedOrderByCreatedDateDesc(Member member,
+                                                                                 RecruitingStatus recruitingStatus,
+                                                                                 Boolean applicantJoined,
+                                                                                 Pageable pageable) {
+        List<Applicant> applicants = query
                 .selectFrom(applicant)
                 .where(
                         applicant.member.eq(member),
-                        applicant.recruiting.eq(recruiting)
+                        recruitingStatueEq(applicant.recruiting.status, recruitingStatus),
+                        joinedEq(applicant.joined, applicantJoined)
+                )
+                .orderBy(applicant.recruiting.createdDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long totalCount = query.select(applicant.count())
+                .from(applicant)
+                .where(
+                        applicant.member.eq(member),
+                        recruitingStatueEq(applicant.recruiting.status, recruitingStatus),
+                        joinedEq(applicant.joined, applicantJoined)
                 )
                 .fetchOne();
+        return new PageImpl<>(applicants, pageable, totalCount);
+    }
+
+    private BooleanBuilder joinedEq(BooleanPath joined, Boolean applicantJoined) {
+        return applicantJoined != null ? new BooleanBuilder(joined.eq(applicantJoined)) : new BooleanBuilder();
+    }
+
+    private BooleanBuilder recruitingStatueEq(EnumPath<RecruitingStatus> status, RecruitingStatus recruitingStatus) {
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+        if (recruitingStatus == null)
+            return booleanBuilder;
+
+        if (recruitingStatus.equals(RecruitingStatus.IN_PROGRESS))
+            booleanBuilder = new BooleanBuilder(status.eq(recruitingStatus));
+        else if (recruitingStatus.equals(RecruitingStatus.DONE) || recruitingStatus.equals(RecruitingStatus.FAILED))
+            booleanBuilder = new BooleanBuilder(status.eq(RecruitingStatus.DONE).or(status.eq(RecruitingStatus.FAILED)));
+
+        return booleanBuilder;
     }
 }

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/exception/InvalidApplicantTypeException.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/exception/InvalidApplicantTypeException.java
@@ -1,0 +1,11 @@
+package com.dnd.niceteam.domain.recruiting.exception;
+
+import com.dnd.niceteam.domain.recruiting.RecruitingStatus;
+import com.dnd.niceteam.error.exception.BusinessException;
+import com.dnd.niceteam.error.exception.ErrorCode;
+
+public class InvalidApplicantTypeException extends BusinessException {
+    public InvalidApplicantTypeException(RecruitingStatus status, Boolean joined) {
+        super(ErrorCode.INVALID_APPLICANT_TYPE, "recruiting status = " + status + ", joined status = " + joined);
+    }
+}

--- a/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
@@ -61,7 +61,8 @@ public enum ErrorCode {
     BOOKMARK_NOT_OWNED(BOOKMARK, SC_BAD_REQUEST, "소유하지 않은 북마크입니다."),
     
     APPLY_ALREADY_ACCEPTED(APPLICANT, SC_BAD_REQUEST, "이미 수락된 지원입니다."),
-    
+    INVALID_APPLICANT_TYPE(APPLICANT, SC_BAD_REQUEST, "유요하지 않는 지원 상태입니다."),
+
     // Vote
     EXPIRED_VOTE_GROUP(VOTE_GROUP, SC_BAD_REQUEST, "내보내기 투표 기간이 만료되었습니다."),
     ALREADY_VOTED(VOTE, SC_BAD_REQUEST, "이미 투표에 참여하셨습니다."),

--- a/src/test/java/com/dnd/niceteam/applicant/controller/ApplicantControllerTest.java
+++ b/src/test/java/com/dnd/niceteam/applicant/controller/ApplicantControllerTest.java
@@ -1,8 +1,11 @@
 package com.dnd.niceteam.applicant.controller;
 
 import com.dnd.niceteam.applicant.dto.ApplicantCreation;
+import com.dnd.niceteam.applicant.dto.ApplicantFind;
 import com.dnd.niceteam.applicant.service.ApplicantService;
 import com.dnd.niceteam.common.RestDocsConfig;
+import com.dnd.niceteam.common.dto.Pagination;
+import com.dnd.niceteam.domain.recruiting.RecruitingStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,13 +19,16 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -88,5 +94,70 @@ class ApplicantControllerTest {
                         document("applicant-delete"
                         )
                 );
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("모집글 지원 현황 목록 조회 API")
+    public void applicantList() throws Exception {
+        // given
+        ApplicantFind.ListRequestDto request = new ApplicantFind.ListRequestDto();
+        request.setApplicantJoined(Boolean.TRUE);
+        request.setRecruitingStatus(RecruitingStatus.IN_PROGRESS);
+        ApplicantFind.ListResponseDto responseDto = new ApplicantFind.ListResponseDto();
+        responseDto.setRecruitingId(1L);
+        responseDto.setRecruitingStatus(RecruitingStatus.IN_PROGRESS);
+        responseDto.setJoined(Boolean.FALSE);
+        responseDto.setRecruitingMemberCount(3);
+        responseDto.setProjectName("project-name");
+
+        Pagination<ApplicantFind.ListResponseDto> applicantResponsePage = Pagination.<ApplicantFind.ListResponseDto>builder()
+                .page(0)
+                .perSize(10)
+                .totalCount(1)
+                .contents(List.of(responseDto))
+                .build();
+        when(applicantService.getMyApplicnts(anyInt(), anyInt(), eq(request), anyString()))
+                .thenReturn(applicantResponsePage);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/recruiting/applicant/me")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .param("page", "1")
+                        .param("perSize", "10")
+        );
+        // then
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andDo(
+                        document("my-applicant-list",
+                        requestParameters(
+                                parameterWithName("page").description("현재 페이지(입력하지 않을 경우, 1)").optional(),
+                                parameterWithName("perSize").description("페이지 별 아이템 개수(입력하지 않을 경우, 10)").optional()
+                        ),
+                        requestFields(
+                                fieldWithPath("recruitingStatus").description("모집글 상태").description("필터링에 따른 짝을 알려줘야함..").optional(),
+                                fieldWithPath("applicantJoined").description("지원 수락 여부").description("필터링에 따른 짝을 알려줘야함..").optional()
+                        ),
+                        responseFields(
+                                beneathPath("data").withSubsectionId("data"),
+                                fieldWithPath("page").description("현재 페이지"),
+                                fieldWithPath("perSize").description("페이지 아이템 개수"),
+                                fieldWithPath("totalCount").description("총 아이템 개수"),
+                                fieldWithPath("totalPages").description("총 페이지 개수"),
+                                fieldWithPath("prev").description("이전 페이지 존재 여부"),
+                                fieldWithPath("next").description("다음 페이지 존재 여부"),
+
+                                fieldWithPath("contents[].recruitingId").description("모집글 식별자(ID)"),
+                                fieldWithPath("contents[].recruitingStatus").description("모집글 상태"),
+                                fieldWithPath("contents[].joined").description("지원 수락 여부"),
+                                fieldWithPath("contents[].projectName").description("프로젝트명"),
+                                fieldWithPath("contents[].recruitingMemberCount").description("모집 인원")
+                        )
+                ));
     }
 }

--- a/src/test/java/com/dnd/niceteam/domain/recruiting/ApplicantRepositoryTest.java
+++ b/src/test/java/com/dnd/niceteam/domain/recruiting/ApplicantRepositoryTest.java
@@ -1,0 +1,122 @@
+package com.dnd.niceteam.domain.recruiting;
+
+import static com.dnd.niceteam.comment.EntityFactoryForTest.*;
+
+import com.dnd.niceteam.common.TestJpaConfig;
+import com.dnd.niceteam.domain.account.Account;
+import com.dnd.niceteam.domain.account.AccountRepository;
+import com.dnd.niceteam.domain.code.Field;
+import com.dnd.niceteam.domain.code.Personality;
+import com.dnd.niceteam.domain.code.Type;
+import com.dnd.niceteam.domain.department.Department;
+import com.dnd.niceteam.domain.department.DepartmentRepository;
+import com.dnd.niceteam.domain.member.Member;
+import com.dnd.niceteam.domain.member.MemberRepository;
+import com.dnd.niceteam.domain.memberscore.MemberScore;
+import com.dnd.niceteam.domain.memberscore.MemberScoreRepository;
+import com.dnd.niceteam.domain.project.Project;
+import com.dnd.niceteam.domain.project.ProjectRepository;
+import com.dnd.niceteam.domain.university.University;
+import com.dnd.niceteam.domain.university.UniversityRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Transactional
+@Import(TestJpaConfig.class)
+class ApplicantRepositoryTest {
+    @Autowired
+    AccountRepository accountRepository;
+    @Autowired
+    UniversityRepository universityRepository;
+    @Autowired
+    DepartmentRepository departmentRepository;
+    @Autowired
+    MemberScoreRepository memberScoreRepository;
+    @Autowired
+    RecruitingRepository recruitingRepository;
+    @Autowired
+    ProjectRepository projectRepisotory;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    ApplicantRepository applicantRepository;
+
+    Account account;
+    University univ;
+    Department department;
+    MemberScore memberScore;
+    Member member;
+    Project project;
+    Recruiting recruiting;
+    Applicant applicant1;
+
+    @BeforeEach
+    void init() {
+        account = accountRepository.save(createAccount());
+        univ = universityRepository.save(createUniversity());
+        department = departmentRepository.save(createDepartment(univ));
+        memberScore = memberScoreRepository.save(createMemberScore());
+        member = memberRepository.save(createMember(account, univ, department, memberScore));
+        project = projectRepisotory.save(createLectureProject(department));
+        recruiting = recruitingRepository.save(createRecruiting(member, project, Type.LECTURE));
+        applicant1 = applicantRepository.save(Applicant.builder()
+                .member(member)
+                .recruiting(recruiting)
+                .joined(Boolean.TRUE)
+                .build());
+    }
+
+    @Test
+    @DisplayName("모집글 지원 현황 목록")
+    void myApplicantList () {
+        // given
+        MemberScore memberScore2 = memberScoreRepository.save(MemberScore.builder()
+                .level(1)
+                .reviewNum(0)
+                .totalParticipationScore(0)
+                .totalTeamAgainScore(0)
+                .build());
+        Account account2 = accountRepository.save(Account.builder()
+                .email("another-email@naver.com")
+                .password("test-password2")
+                .build());
+        Member anotherMember = memberRepository.save(Member.builder()
+                .account(account2)
+                .university(univ)
+                .department(department)
+                .memberScore(memberScore2)
+                .nickname("테스트닉네임2")
+                .admissionYear(2017)
+                .personality(new Personality(Personality.Adjective.LOGICAL, Personality.Noun.LEADER))
+                .interestingFields(Set.of(Field.IT_SW_GAME, Field.DESIGN))
+                .introduction("")
+                .introductionUrl("")
+                .build());
+        Applicant applicant2 = applicantRepository.save(Applicant.builder()
+                .member(anotherMember)
+                .recruiting(recruiting)
+                .joined(Boolean.FALSE)
+                .build());
+        Pageable pageable = PageRequest.of(0, 10);
+        // when
+        Page<Applicant> myApplicantsPage = applicantRepository.findAllByMemberAndRecruitingStatusAndJoinedOrderByCreatedDateDesc(member, null, null, pageable);
+        Page<Applicant> myApplicants2PageWithFiltered = applicantRepository.findAllByMemberAndRecruitingStatusAndJoinedOrderByCreatedDateDesc(anotherMember, RecruitingStatus.IN_PROGRESS, Boolean.TRUE, pageable);
+
+        // then
+        assertThat(myApplicantsPage.getContent().size()).isEqualTo(1);
+        assertThat(myApplicants2PageWithFiltered.getContent().size()).isZero();
+    }
+}


### PR DESCRIPTION
# 구현 내용/방법
####  지원 현황 목록 조회 기능 구현하였습니다.
- 현재는 Applicant 의 `joined` 필드와 해당 지원한 모집글의 상태(`status`)에 따라 
지원 **대기중**인지 **수락**인지 **지원 실패**인지 분류하여 조회되도록 진행했습니다.
  - RecruitingStatus.IN_PROGRESS 이고 joined=true => 수락
  - RecruitingStatus.IN_PROGRESS 이고 joined=false => 지원중
  - RecruitingStatus.IN_PROGRESS 아니고 joined=false => 지원 실패
  - 이외의 경우(`status`가 null인데 `joined`가 null이 아닌 경우, 혹은 그 반대)는 `InvalidApplicantTypeException` 예외 발생 처리하였습니다.
  - 아예 두 값 모두 null인 경우는 전체 지원 현황이 조회됩니다.

# 리뷰 필요
- 추후에, 지원자의 상태값을 따로 두어서 필터링 탭에 따라 상태값(**WAITING**, **ACCEPTED**, **FAILED**)으로만 분류되도록 진행할 수 있을 것 같습니다.

close #114 