### PR TITLE
fix(Applicant) : 지원현황 목록 조회 API 요청타입 수정

### DIFF
--- a/src/main/java/com/dnd/niceteam/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/dnd/niceteam/applicant/controller/ApplicantController.java
@@ -5,6 +5,7 @@ import com.dnd.niceteam.applicant.dto.ApplicantFind;
 import com.dnd.niceteam.applicant.service.ApplicantService;
 import com.dnd.niceteam.common.dto.ApiResult;
 import com.dnd.niceteam.common.dto.Pagination;
+import com.dnd.niceteam.domain.recruiting.RecruitingStatus;
 import com.dnd.niceteam.security.CurrentUsername;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -39,9 +40,10 @@ public class ApplicantController {
     @GetMapping("/applicant/me")
     public ResponseEntity<ApiResult<Pagination<ApplicantFind.ListResponseDto>>> myApplyList(@RequestParam(defaultValue = "1", required = false) Integer page,
                                                                                             @RequestParam(defaultValue = "10", required = false) Integer perSize,
-                                                                                            @RequestBody ApplicantFind.ListRequestDto requestDto,
+                                                                                            @RequestParam(required = false) RecruitingStatus recruitingStatus,
+                                                                                            @RequestParam(required = false) Boolean applicantJoined,
                                                                                             @CurrentUsername String username) {
-        Pagination<ApplicantFind.ListResponseDto> applications = applicantService.getMyApplicnts(page, perSize, requestDto, username);
+        Pagination<ApplicantFind.ListResponseDto> applications = applicantService.getMyApplicnts(page, perSize, recruitingStatus, applicantJoined, username);
         ApiResult<Pagination<ApplicantFind.ListResponseDto>> apiResult = ApiResult.success(applications);
         return ResponseEntity.ok(apiResult);
     }

--- a/src/main/java/com/dnd/niceteam/applicant/dto/ApplicantFind.java
+++ b/src/main/java/com/dnd/niceteam/applicant/dto/ApplicantFind.java
@@ -6,12 +6,6 @@ import lombok.Data;
 
 public interface ApplicantFind {
     @Data
-    class ListRequestDto {
-        RecruitingStatus recruitingStatus;
-        Boolean applicantJoined;
-    }
-
-    @Data
     class ListResponseDto {
         Long recruitingId;
         RecruitingStatus recruitingStatus;

--- a/src/main/java/com/dnd/niceteam/applicant/service/ApplicantService.java
+++ b/src/main/java/com/dnd/niceteam/applicant/service/ApplicantService.java
@@ -69,23 +69,24 @@ public class ApplicantService {
     }
 
     public Pagination<ApplicantFind.ListResponseDto> getMyApplicnts(int page, int perSize,
-                                                                    ApplicantFind.ListRequestDto requestDto, String username) {
-        if (isInvalidFiltering(requestDto)) {
-            throw new InvalidApplicantTypeException(requestDto.getRecruitingStatus(), requestDto.getApplicantJoined());
+                                                                    RecruitingStatus recruitingStatus,
+                                                                    Boolean applicantJoined, String username) {
+        if (isInvalidFiltering(recruitingStatus, applicantJoined)) {
+            throw new InvalidApplicantTypeException(recruitingStatus, applicantJoined);
         }
         Member member = MemberUtils.findMemberByEmail(username, memberRepository);
 
         Pageable pageable = PageRequest.of(page - 1, perSize);
         Page<ApplicantFind.ListResponseDto> applicationPages = applicantRepository.findAllByMemberAndRecruitingStatusAndJoinedOrderByCreatedDateDesc(
-                member, requestDto.getRecruitingStatus(), requestDto.getApplicantJoined(), pageable)
+                member, recruitingStatus, applicantJoined, pageable)
                 .map(ApplicantFind.ListResponseDto::from);
 
         return PaginationUtil.pageToPagination(applicationPages);
     }
 
-    private boolean isInvalidFiltering(ApplicantFind.ListRequestDto requestDto) {
-        return (isNull(requestDto.getApplicantJoined()) && requestDto.getRecruitingStatus() != null)
-                || (isNull(requestDto.getRecruitingStatus()) && requestDto.getApplicantJoined() != null);
+    private boolean isInvalidFiltering(RecruitingStatus recruitingStatus, Boolean applicantJoined) {
+        return (isNull(applicantJoined) && !isNull(recruitingStatus))
+                || (isNull(recruitingStatus) && !isNull(applicantJoined));
     }
 
     private boolean isApplyImpossible(RecruitingStatus recruitingStatus) {

--- a/src/test/java/com/dnd/niceteam/applicant/service/ApplicantServiceTest.java
+++ b/src/test/java/com/dnd/niceteam/applicant/service/ApplicantServiceTest.java
@@ -213,17 +213,13 @@ class ApplicantServiceTest {
                 .recruiting(mockRecruiting)
                 .joined(Boolean.TRUE)
                 .build();
-        ApplicantFind.ListRequestDto requestDto = new ApplicantFind.ListRequestDto();
-        requestDto.setRecruitingStatus(RecruitingStatus.IN_PROGRESS);
-        requestDto.setApplicantJoined(Boolean.TRUE);
-
         Pageable pageable = PageRequest.of(0, 10);
         when(mockMemberRepository.findByEmail(email)).thenReturn(Optional.ofNullable(mockMember));
         when(mockApplicantRepository.findAllByMemberAndRecruitingStatusAndJoinedOrderByCreatedDateDesc(
-                mockMember, RecruitingStatus.IN_PROGRESS, Boolean.TRUE, pageable))
+                any(Member.class), any(RecruitingStatus.class), anyBoolean(), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of(applicant), pageable, 1L));
         // when
-        Pagination<ApplicantFind.ListResponseDto> myApplicntsDto = applicantService.getMyApplicnts(1, 10, requestDto, email);
+        Pagination<ApplicantFind.ListResponseDto> myApplicntsDto = applicantService.getMyApplicnts(1, 10, RecruitingStatus.IN_PROGRESS, Boolean.TRUE, email);
 
         // then
         assertThat(myApplicntsDto.getContents().size()).isEqualTo(1);

--- a/src/test/java/com/dnd/niceteam/domain/recruiting/ApplicantRepositoryTest.java
+++ b/src/test/java/com/dnd/niceteam/domain/recruiting/ApplicantRepositoryTest.java
@@ -5,9 +5,7 @@ import static com.dnd.niceteam.comment.EntityFactoryForTest.*;
 import com.dnd.niceteam.common.TestJpaConfig;
 import com.dnd.niceteam.domain.account.Account;
 import com.dnd.niceteam.domain.account.AccountRepository;
-import com.dnd.niceteam.domain.code.Field;
-import com.dnd.niceteam.domain.code.Personality;
-import com.dnd.niceteam.domain.code.Type;
+import com.dnd.niceteam.domain.code.*;
 import com.dnd.niceteam.domain.department.Department;
 import com.dnd.niceteam.domain.department.DepartmentRepository;
 import com.dnd.niceteam.domain.member.Member;
@@ -16,6 +14,7 @@ import com.dnd.niceteam.domain.memberscore.MemberScore;
 import com.dnd.niceteam.domain.memberscore.MemberScoreRepository;
 import com.dnd.niceteam.domain.project.Project;
 import com.dnd.niceteam.domain.project.ProjectRepository;
+import com.dnd.niceteam.domain.project.SideProject;
 import com.dnd.niceteam.domain.university.University;
 import com.dnd.niceteam.domain.university.UniversityRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +28,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -110,13 +112,50 @@ class ApplicantRepositoryTest {
                 .recruiting(recruiting)
                 .joined(Boolean.FALSE)
                 .build());
+        Project project1 = projectRepisotory.save(SideProject.builder()
+                .name("project1 name")
+                .startDate(LocalDate.of(2022,12,20))
+                .endDate(LocalDate.of(2023,3,20))
+                .field(Field.IT_SW_GAME)
+                .fieldCategory(FieldCategory.STUDY)
+                .build());
+        Recruiting recruiting1 = recruitingRepository.save(Recruiting.builder()
+                .content("another recruiting content")
+                .title("another recruiting title")
+                .member(anotherMember)
+                .project(project1)
+                .introLink("another recruiting introLink")
+                .activityArea(ActivityArea.BUSAN)
+                .recruitingMemberCount(4)
+                .recruitingType(Type.SIDE)
+                .recruitingEndDate(LocalDate.of(2022, 12, 29))
+                .status(RecruitingStatus.FAILED)
+                .commentCount(0)
+                .poolUpCount(0)
+                .poolUpDate(LocalDateTime.now())
+                .bookmarkCount(0)
+                .personalityNouns(Set.of(Personality.Noun.JACK_OF_ALL_TRADES))
+                .personalityAdjectives(Set.of(Personality.Adjective.LOGICAL))
+                .activityDayTimes(Set.of(ActivityDayTime.builder().
+                        dayOfWeek(DayOfWeek.FRI)
+                        .startTime(LocalTime.of(17, 0)).endTime(LocalTime.of(20, 0))
+                        .build()))
+                .build());
+        applicantRepository.save(Applicant.builder()
+                        .member(member)
+                        .recruiting(recruiting1)
+                        .joined(Boolean.FALSE)
+                        .build());
         Pageable pageable = PageRequest.of(0, 10);
+
         // when
         Page<Applicant> myApplicantsPage = applicantRepository.findAllByMemberAndRecruitingStatusAndJoinedOrderByCreatedDateDesc(member, null, null, pageable);
-        Page<Applicant> myApplicants2PageWithFiltered = applicantRepository.findAllByMemberAndRecruitingStatusAndJoinedOrderByCreatedDateDesc(anotherMember, RecruitingStatus.IN_PROGRESS, Boolean.TRUE, pageable);
+        Page<Applicant> myApplicantsPageWithFiltering = applicantRepository.findAllByMemberAndRecruitingStatusAndJoinedOrderByCreatedDateDesc(anotherMember, RecruitingStatus.IN_PROGRESS, Boolean.TRUE, pageable);
+        Page<Applicant> myApplicantsPageWithFilteredPage = applicantRepository.findAllByMemberAndRecruitingStatusAndJoinedOrderByCreatedDateDesc(member, RecruitingStatus.FAILED, Boolean.FALSE, pageable);
 
         // then
-        assertThat(myApplicantsPage.getContent().size()).isEqualTo(1);
-        assertThat(myApplicants2PageWithFiltered.getContent().size()).isZero();
+        assertThat(myApplicantsPage.getContent().size()).isEqualTo(2);  // 전체조회
+        assertThat(myApplicantsPageWithFiltering.getContent().size()).isZero();
+        assertThat(myApplicantsPageWithFilteredPage.getContent().size()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
# 구현 내용/방법
- 문제 : GET 요청 시 body에 데이터를 담으면 안드로이드 쪽에서 문제 발생
```
method GET must not have a request body.
java.lang.IllegalArgumentException: method GET must not have a request body.
```

- 기존 : 요청 시, body에 데이터를 보내는 방식 (`@RequestBody` 이용)
- 수정 : 요청 시, parameter로 데이터를 보내는 방식 (`@RequestParam` 이용)

➕ `ApplicantControllerTest`에서는 ObjectMapper 자체를 사용하지 않게 되서 제거했습니다.


close #121 
