### PR TITLE
Feature/#120 모집글 끌올 기능 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -20,8 +20,8 @@
 - xref:applicant.adoc[Applicant (지원자)]
 - xref:comment.adoc[Comment (댓글 및 답글)]
 - xref:bookmark.adoc[Bookmark (북마크)]
-- xref:bookmark.adoc[Member Review (팀원 후기)]
-- xref:bookmark.adoc[Project (팀플)]
+- xref:member-review.adoc[Member Review (팀원 후기)]
+- xref:project.adoc[Project (팀플)]
 
 
 == HTTP Method

--- a/src/docs/asciidoc/project.adoc
+++ b/src/docs/asciidoc/project.adoc
@@ -19,3 +19,9 @@ operation::get-my-project-list[snippets='http-request,request-parameters,http-re
 == 내 팀플 목록 조회
 
 operation::get-my-project[snippets='http-request,request-parameters,http-response,response-fields-data']
+
+
+[[add-project-member]]
+== 프로젝트 팀원 등록
+
+operation::add-project-member[snippets='http-request,request-parameters,http-response,response-fields-data']

--- a/src/docs/asciidoc/recruiting.adoc
+++ b/src/docs/asciidoc/recruiting.adoc
@@ -44,3 +44,8 @@ operation::recruiting-modify[snippets='http-request,request-parameters,http-resp
 == 모집글 제거
 
 operation::recruiting-remove[snippets='http-request,request-parameters,http-response,response-fields-data']
+
+[[recruiting-poolup]]
+== 모집글 끌올
+
+operation::recruiting-poolup[snippets='http-request,request-parameters,http-response,response-fields-data']

--- a/src/main/java/com/dnd/niceteam/applicant/service/ApplicantService.java
+++ b/src/main/java/com/dnd/niceteam/applicant/service/ApplicantService.java
@@ -43,6 +43,8 @@ public class ApplicantService {
                 .member(member)
                 .recruiting(recruiting)
                 .build());
+        recruiting.addApplicant(savedApplicant);
+
         ApplicantCreation.ResponseDto responseDto = new ApplicantCreation.ResponseDto();
         responseDto.setId(savedApplicant.getId());
         return responseDto;
@@ -66,6 +68,7 @@ public class ApplicantService {
             projectMemberRepository.delete(projectMember);
         }
         applicantRepository.delete(foundApplicant);
+        recruiting.removeApplicant(foundApplicant);
     }
 
     public Pagination<ApplicantFind.ListResponseDto> getMyApplicnts(int page, int perSize,

--- a/src/main/java/com/dnd/niceteam/domain/project/Project.java
+++ b/src/main/java/com/dnd/niceteam/domain/project/Project.java
@@ -93,4 +93,8 @@ public abstract class Project extends BaseEntity {
         return projectMembers.contains(projectMember);
     }
 
+    public boolean isNotStarted() {
+        return ProjectStatus.NOT_STARTED.equals(this.getStatus());
+    }
+
 }

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/Recruiting.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/Recruiting.java
@@ -71,8 +71,9 @@ public class Recruiting extends BaseEntity {
     @Column(name = "pool_up_count", nullable = false)
     private Integer poolUpCount;
 
-    @Column(name = "pool_up_date")
-    private LocalDateTime poolUpDate;
+    @Builder.Default
+    @Column(name = "pool_up_date", nullable = false)
+    private LocalDateTime poolUpDate = LocalDateTime.now();
 
     @Builder.Default
     @Column(name = "intro_link", nullable = false)
@@ -103,6 +104,12 @@ public class Recruiting extends BaseEntity {
             joinColumns = @JoinColumn(name= "recruiting_id", nullable = false))
     @Column(name = "activity_day_times", length = 50, nullable = false)
     private Set<ActivityDayTime> activityDayTimes = new HashSet<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "recruiting",
+            cascade = CascadeType.PERSIST,
+            orphanRemoval = true)
+    private Set<Applicant> applicants = new HashSet<>();
 
     public void plusCommentCount() {
         this.commentCount += 1;
@@ -140,5 +147,19 @@ public class Recruiting extends BaseEntity {
         activityDayTimes = dto.getActivityDayTimes().stream().map(ActivityDayTimeDto::toEntity).collect(Collectors.toSet());   // dto로 수정 필요.
         personalityAdjectives = dto.getPersonalityAdjectives();
         personalityNouns = dto.getPersonalityNouns();
+    }
+
+    public void updatePoolUpDate(LocalDateTime poolUpDate) {
+        this.poolUpDate = poolUpDate;
+    }
+    public void plusPoolUpCount() {
+        this.poolUpCount += 1;
+    }
+
+    public void addApplicant(Applicant applicant) {
+        applicants.add(applicant);
+    }
+    public void removeApplicant(Applicant applicant) {
+        applicants.remove(applicant);
     }
 }

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/RecruitingRepositoryCustomImpl.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/RecruitingRepositoryCustomImpl.java
@@ -63,10 +63,10 @@ public class RecruitingRepositoryCustomImpl implements RecruitingRepositoryCusto
                 .select(recruiting)
                 .from(recruiting)
                 .join(recruiting.project, project)
-                .where(project
+                .on(project
                         .in(findSideProjectsBySearchWordAndField(searchWord, field))
-                        .and(project.type.eq(Type.SIDE))
                         .or(nameContains(recruiting.title, searchWord))
+                        .and(project.type.eq(Type.SIDE))
                 )
                 .orderBy(recruiting.createdDate.desc())
                 .offset(pageable.getOffset())

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/RecruitingStatus.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/RecruitingStatus.java
@@ -1,7 +1,31 @@
 package com.dnd.niceteam.domain.recruiting;
 
-public enum RecruitingStatus {
-    IN_PROGRESS,
-    DONE,
-    FAILED
+import com.dnd.niceteam.domain.common.EnumMapperType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RecruitingStatus implements EnumMapperType {
+    IN_PROGRESS("진행중"),
+    DONE("완료"),
+    FAILED("실패")
+    ;
+    private final String title;
+    @Override
+    public String getCode() {
+        return name();
+    }
+
+    @Override
+    public String getTitle() {
+        return title;
+    }
+
+    @JsonCreator
+    public static RecruitingStatus fromJson(@JsonProperty("code") String code) {
+        return valueOf(code);
+    }
 }

--- a/src/main/java/com/dnd/niceteam/domain/recruiting/exception/PoolUpImpossibleRecruitingException.java
+++ b/src/main/java/com/dnd/niceteam/domain/recruiting/exception/PoolUpImpossibleRecruitingException.java
@@ -1,0 +1,11 @@
+package com.dnd.niceteam.domain.recruiting.exception;
+
+import com.dnd.niceteam.domain.recruiting.RecruitingStatus;
+import com.dnd.niceteam.error.exception.BusinessException;
+import com.dnd.niceteam.error.exception.ErrorCode;
+
+public class PoolUpImpossibleRecruitingException extends BusinessException {
+    public PoolUpImpossibleRecruitingException(RecruitingStatus status) {
+        super(ErrorCode.POOL_UP_IMPOSSIBLE_RECRUITING, "recruiting status = " + status);
+    }
+}

--- a/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/niceteam/error/exception/ErrorCode.java
@@ -52,6 +52,8 @@ public enum ErrorCode {
 
     APPLY_IMPOSSIBLE_RECRUITING(RECRUITING, SC_BAD_REQUEST, "지원 불가능한 모집글입니다."),
     APPLY_CANCEL_IMPOSSIBLE_RECRUITING(RECRUITING, SC_BAD_REQUEST, "지원 취소가 불가능한 모집글입니다."),
+    POOL_UP_IMPOSSIBLE_RECRUITING(RECRUITING, SC_BAD_REQUEST, "끌올이 불가능한 모집글입니다."),
+
     APPLICANT_NOT_FOUND(APPLICANT, SC_NOT_FOUND, "존재하지 않는 지원자입니다."),
 
     COMMENT_NOT_FOUND(COMMENT, SC_NOT_FOUND, "존재하지 않는 댓글입니다."),
@@ -62,7 +64,6 @@ public enum ErrorCode {
     
     APPLY_ALREADY_ACCEPTED(APPLICANT, SC_BAD_REQUEST, "이미 수락된 지원입니다."),
     INVALID_APPLICANT_TYPE(APPLICANT, SC_BAD_REQUEST, "유요하지 않는 지원 상태입니다."),
-
     // Vote
     EXPIRED_VOTE_GROUP(VOTE_GROUP, SC_BAD_REQUEST, "내보내기 투표 기간이 만료되었습니다."),
     ALREADY_VOTED(VOTE, SC_BAD_REQUEST, "이미 투표에 참여하셨습니다."),

--- a/src/main/java/com/dnd/niceteam/project/dto/ProjectRequest.java
+++ b/src/main/java/com/dnd/niceteam/project/dto/ProjectRequest.java
@@ -64,7 +64,7 @@ public interface ProjectRequest {
                     .build();
         }
 
-        public static ProjectRequest.Register createProjecRegistertRequestDto(RecruitingCreation.RequestDto recruitingReqDto) {
+        public static ProjectRequest.Register from (RecruitingCreation.RequestDto recruitingReqDto) {
             ProjectRequest.Register projectDto = new ProjectRequest.Register();
             projectDto.setType(recruitingReqDto.getRecruitingType());
             projectDto.setStartDate(recruitingReqDto.getProjectStartDate());
@@ -106,7 +106,7 @@ public interface ProjectRequest {
         private Field field;
         private FieldCategory fieldCategory;
 
-        public static ProjectRequest.Update createProjectUpdateRequestDto (RecruitingModify.RequestDto requestDto) {
+        public static ProjectRequest.Update of (RecruitingModify.RequestDto requestDto) {
             ProjectRequest.Update dto = new ProjectRequest.Update();
             dto.setName(requestDto.getProjectName());
             dto.setStartDate(requestDto.getProjectStartDate());

--- a/src/main/java/com/dnd/niceteam/recruiting/controller/RecruitingController.java
+++ b/src/main/java/com/dnd/niceteam/recruiting/controller/RecruitingController.java
@@ -87,15 +87,27 @@ public class RecruitingController {
 
     @PutMapping("/{recruitingId}")
     public ResponseEntity<ApiResult<RecruitingModify.ResponseDto>> recruitingModify (@PathVariable @NotNull Long recruitingId,
-                                                                                     @RequestBody RecruitingModify.RequestDto requestDto) {
-        RecruitingModify.ResponseDto updatedRecruiting = recruitingService.modifyProjectAndRecruiting(recruitingId, requestDto);
+                                                                                     @RequestBody @Valid @NotNull RecruitingModify.RequestDto requestDto,
+                                                                                     @CurrentUsername String username) {
+        RecruitingModify.ResponseDto updatedRecruiting = recruitingService.modifyProjectAndRecruiting(recruitingId, requestDto, username);
         ApiResult<RecruitingModify.ResponseDto> apiResult = ApiResult.success(updatedRecruiting);
         return ResponseEntity.ok(apiResult);
     }
 
     @DeleteMapping("/{recruitingId}")
-    public ResponseEntity<ApiResult<Void>> recruitingRemove (@PathVariable @NotNull Long recruitingId) {
-        recruitingService.removeRecruiting(recruitingId);
+    public ResponseEntity<ApiResult<Void>> recruitingRemove (@PathVariable @NotNull Long recruitingId,
+                                                             @CurrentUsername String username) {
+        recruitingService.removeRecruiting(recruitingId, username);
+
+        ApiResult<Void> apiResult = ApiResult.<Void>success().build();
+        return ResponseEntity.ok(apiResult);
+    }
+
+    @PutMapping("/{recruitingId}/pool-up")
+    public ResponseEntity<ApiResult<Void>> recruitingPoolUp (@PathVariable @NotNull Long recruitingId,
+                                                             @RequestBody @Valid RecruitingModify.PoolUpRequestDto requestDto,
+                                                             @CurrentUsername String username) {
+        recruitingService.poolUpRecruiting(recruitingId, requestDto, username);
 
         ApiResult<Void> apiResult = ApiResult.<Void>success().build();
         return ResponseEntity.ok(apiResult);

--- a/src/main/java/com/dnd/niceteam/recruiting/dto/RecruitingCreation.java
+++ b/src/main/java/com/dnd/niceteam/recruiting/dto/RecruitingCreation.java
@@ -11,7 +11,9 @@ import lombok.Data;
 import org.springframework.lang.Nullable;
 
 import javax.validation.constraints.FutureOrPresent;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
@@ -21,9 +23,11 @@ import java.util.stream.Collectors;
 public interface RecruitingCreation {
     @Data
     class RequestDto {
-        @NotNull
+        @NotBlank(message = "제목에 텍스트를 입력해주세요.")
+        @Size(max = 30, message = "제목은 30자 이내로 입력해주세요.")
         private String title;
         @NotNull
+        @Size(max = 400, message = "400자 이내로 입력해주세요.")
         private String content;
         @NotNull
         private Integer recruitingMemberCount;
@@ -79,7 +83,6 @@ public interface RecruitingCreation {
                     .bookmarkCount(0)
                     .commentCount(0)
                     .poolUpCount(0)
-                    .poolUpDate(null)
                     .introLink(introLink)
                     .personalityAdjectives(personalityAdjectives)
                     .personalityNouns(personalityNouns)

--- a/src/main/java/com/dnd/niceteam/recruiting/dto/RecruitingModify.java
+++ b/src/main/java/com/dnd/niceteam/recruiting/dto/RecruitingModify.java
@@ -8,11 +8,11 @@ import org.springframework.lang.Nullable;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
 public interface RecruitingModify {
-    // 수정 (바뀌지 않은 것도 담아서 보내는 방식)
     @Data
     class RequestDto {
         @NotNull
@@ -70,5 +70,10 @@ public interface RecruitingModify {
 
             return dto;
         }
+    }
+
+    @Data
+    class PoolUpRequestDto {
+        LocalDateTime poolUpDate;
     }
 }

--- a/src/test/java/com/dnd/niceteam/domain/recruiting/RecruitingRepositoryTest.java
+++ b/src/test/java/com/dnd/niceteam/domain/recruiting/RecruitingRepositoryTest.java
@@ -122,7 +122,8 @@ class RecruitingRepositoryTest {
         em.clear();
 
         // when
-        Page<Recruiting> foundMyRecruitings = recruitingRepository.findPageByMemberAndStatusOrderByCreatedDateDesc(pageable, member, RecruitingStatus.DONE);
+        Page<Recruiting> foundMyRecruitings = recruitingRepository.findPageByMemberAndStatusOrderByCreatedDateDesc(
+                pageable, member, RecruitingStatus.DONE);
 
         assertThat(foundMyRecruitings.getTotalPages()).isEqualTo(1);
         assertThat(foundMyRecruitings.getTotalElements()).isEqualTo(1);
@@ -185,7 +186,8 @@ class RecruitingRepositoryTest {
 
         // when
         pageable = PageRequest.of(page - 1, 4);
-        Page<Recruiting> foundRecommendedRecruitings = recruitingRepository.findAllByInterestingFieldsOrderByWriterLevel(member.getInterestingFields(), pageable);
+        Page<Recruiting> foundRecommendedRecruitings = recruitingRepository.findAllByInterestingFieldsOrderByWriterLevel(
+                member.getInterestingFields(), pageable);
 
         // then
         assertThat(foundRecommendedRecruitings.getTotalElements()).isEqualTo(2);
@@ -243,15 +245,24 @@ class RecruitingRepositoryTest {
         em.clear();
 
         // when - 사이드
-        List<Recruiting> sideRecruitingsWithKeyword = recruitingRepository.findAllSideBySearchWordAndFieldOrderByCreatedDate("proj", null, pageable).getContent();
-        List<Recruiting> sideRecruitingsWithKeywordAndField = recruitingRepository.findAllSideBySearchWordAndFieldOrderByCreatedDate("proj", Field.IT_SW_GAME, pageable).getContent();
-        List<Recruiting> sideRecruitingsWithField = recruitingRepository.findAllSideBySearchWordAndFieldOrderByCreatedDate(null, Field.IT_SW_GAME, pageable).getContent();
-        List<Recruiting> sideRecruitings = recruitingRepository.findAllSideBySearchWordAndFieldOrderByCreatedDate(null, null, pageable).getContent();
+        List<Recruiting> sideRecruitingsWithKeyword = recruitingRepository
+                .findAllSideBySearchWordAndFieldOrderByCreatedDate("proj", null, pageable)
+                .getContent();
+        List<Recruiting> sideRecruitingsWithKeywordAndField = recruitingRepository
+                .findAllSideBySearchWordAndFieldOrderByCreatedDate("proj", Field.IT_SW_GAME, pageable)
+                .getContent();
+        List<Recruiting> sideRecruitingsWithField = recruitingRepository
+                .findAllSideBySearchWordAndFieldOrderByCreatedDate(null, Field.IT_SW_GAME, pageable)
+                .getContent();
+        List<Recruiting> defaultSideRecruitings = recruitingRepository
+                .findAllSideBySearchWordAndFieldOrderByCreatedDate(null, null, pageable)
+                .getContent();
         // then
         assertThat(sideRecruitingsWithKeyword.size()).isEqualTo(3);
         assertThat(sideRecruitingsWithKeywordAndField.size()).isEqualTo(2);
         assertThat(sideRecruitingsWithField.size()).isEqualTo(2);
-        assertThat(sideRecruitings.get(0).getProject().getName()).isEqualTo("project-side2");   // just 최신순
+        assertThat(defaultSideRecruitings.size()).isEqualTo(3);   // 기본 조회
+        assertThat(defaultSideRecruitings.get(0).getProject().getName()).isEqualTo("project-side2");   // just 최신순
     }
 
     @Test
@@ -260,7 +271,10 @@ class RecruitingRepositoryTest {
         Project lectureProjectNonsameDepartment = projectRepository.save(LectureProject.builder()
                 .name("project-0")
                 .professor("common-professor")
-                .lectureTimes(Set.of(LectureTime.builder().dayOfWeek(DayOfWeek.MON).startTime(LocalTime.of(9,0)).build()))
+                .lectureTimes(Set.of(LectureTime.builder()
+                                .dayOfWeek(DayOfWeek.MON)
+                                .startTime(LocalTime.of(9,0))
+                                .build()))
                 .department(departmentRepository.save(Department.builder()
                         .name("미디어커뮤니케이션 학과")
                         .mainBranchType("main")
@@ -274,7 +288,10 @@ class RecruitingRepositoryTest {
         Project lectureProject1 = projectRepository.save(LectureProject.builder()
                 .name("project-")
                 .professor("common-professor")
-                .lectureTimes(Set.of(LectureTime.builder().dayOfWeek(DayOfWeek.MON).startTime(LocalTime.of(9,0)).build()))
+                .lectureTimes(Set.of(LectureTime.builder()
+                        .dayOfWeek(DayOfWeek.MON)
+                        .startTime(LocalTime.of(9,0))
+                        .build()))
                 .department(department)
                 .startDate(LocalDate.of(2022, 7, 4))
                 .endDate(LocalDate.of(2022, 8, 28))
@@ -282,7 +299,8 @@ class RecruitingRepositoryTest {
         Project lectureProject2 = projectRepository.save(LectureProject.builder()
                 .name("project-side2")
                 .professor("only-professor")
-                .lectureTimes(Set.of(LectureTime.builder().dayOfWeek(DayOfWeek.MON).startTime(LocalTime.of(9,0)).build()))
+                .lectureTimes(
+                        Set.of(LectureTime.builder().dayOfWeek(DayOfWeek.MON).startTime(LocalTime.of(9,0)).build()))
                 .department(department)
                 .startDate(LocalDate.of(2022, 7, 4))
                 .endDate(LocalDate.of(2022, 8, 28))
@@ -310,11 +328,21 @@ class RecruitingRepositoryTest {
         em.clear();
 
         // when - 강의
-        List<Recruiting> lectureRecruitingsWithoutKeyword = recruitingRepository.findAllLectureBySearchWordAndDepartmentOrderByCreatedDate(null, department.getName(), pageable).getContent();  // 1개나와야함 (name은 같지만, sw가 다르므로
-        List<Recruiting> lectureRecruitingsWithKeyword = recruitingRepository.findAllLectureBySearchWordAndDepartmentOrderByCreatedDate("project", department.getName(), pageable).getContent();  // 1개나와야함 (name은 같지만, sw가 다르므로
-        List<Recruiting> lectureRecruitingsWithDiffKeyword = recruitingRepository.findAllLectureBySearchWordAndDepartmentOrderByCreatedDate("33", department.getName(), pageable).getContent();  // 1개나와야함 (name은 같지만, sw가 다르므로
-        List<Recruiting> lectureRecruitingsWithKeywordSameWithLectureTitle = recruitingRepository.findAllLectureBySearchWordAndDepartmentOrderByCreatedDate("lecture-type-recruiting-title", department.getName(), pageable).getContent();  // 1개나와야함 (name은 같지만, sw가 다르므로
-        List<Recruiting> lectureRecruitingsWithKeywordSameWithProfessor = recruitingRepository.findAllLectureBySearchWordAndDepartmentOrderByCreatedDate("only-professor", department.getName(), pageable).getContent();  // 1개나와야함 (name은 같지만, sw가 다르므로
+        List<Recruiting> lectureRecruitingsWithoutKeyword = recruitingRepository
+                .findAllLectureBySearchWordAndDepartmentOrderByCreatedDate(null, department.getName(), pageable)
+                .getContent();
+        List<Recruiting> lectureRecruitingsWithKeyword = recruitingRepository
+                .findAllLectureBySearchWordAndDepartmentOrderByCreatedDate("project", department.getName(), pageable)
+                .getContent();
+        List<Recruiting> lectureRecruitingsWithDiffKeyword = recruitingRepository
+                .findAllLectureBySearchWordAndDepartmentOrderByCreatedDate("33", department.getName(), pageable)
+                .getContent();
+        List<Recruiting> lectureRecruitingsWithKeywordSameWithLectureTitle = recruitingRepository
+                .findAllLectureBySearchWordAndDepartmentOrderByCreatedDate("lecture-type-recruiting-title", department.getName(), pageable)
+                .getContent();
+        List<Recruiting> lectureRecruitingsWithKeywordSameWithProfessor = recruitingRepository
+                .findAllLectureBySearchWordAndDepartmentOrderByCreatedDate("only-professor", department.getName(), pageable)
+                .getContent();
         // then
         assertThat(lectureRecruitingsWithoutKeyword.size()).isEqualTo(2);   // 검색 없을 때는 같은 전공
         assertThat(lectureRecruitingsWithKeyword.size()).isEqualTo(3);   // 검색 있을 때는 전공 필터링X


### PR DESCRIPTION
# 구현 내용/방법

- 모집글 끌올 기능 관련 컨트롤러, 서비스 메서드 추가
- 관련 테스트코드 메서드 추가
  - RecruitingServiceTest.java: 불통하던 문제 해결 후 함께 커밋합니다. 
- 필요한 예외 클래스 추가

➕ 모집글 생성 시, 끌올날짜는 생성날짜로 초기화합니다.

close #120 

---
### 추가 리팩토링
- 모집글 삭제 & 수정 시, 작성자 권한 로직 추가
- `isProjecrNotStarted()` 메서드 위치 이동(-> `Project.java`) 및 메서드명 수정
- DTO -> Entity, DTO -> DTO 변환 메서드명 수정

- `Applicant` 관련 클래스 commit 내역 
  - 모집글 제거 시 관련 지원자도 자동 제거되도록 했습니다. (cascade 및 orphanRemoval 설정)
  - 참고
  ```
  지원한 모집글이 삭제될 경우, 
  - 프로젝트 제거 여부
    - 프로젝트가 시작되지 않았다면 연관 프로젝트 제거
    - 프로젝트가 시작되었다면 연관 프로젝트 제거 X
  - 지원자 제거
    - 모집글이 제거되면 지원자도 제거된다. -> cascade 및 orphanRemoval 설정
      (지원현황에서 데이터가 조회 X)
  ```

### docs 수정  @m-dzn 
- `index.adoc`에서 Member-Review와 Project가 Bookmark 페이지에 링크되어있어서 수정했습니다.
- `ProjectControllerTest.java`에 추가 작성하신 코드가 `project.adoc`에는 반영되어 있지 않아서 추가했습니다.